### PR TITLE
Feature/로그인 회원가입 UI 구성

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Outlet } from 'react-router-dom';
 import { RecoilRoot } from 'recoil';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from '@material-tailwind/react';
@@ -16,7 +17,7 @@ const App = () => {
     <RecoilRoot>
       <QueryClientProvider client={queryClient}>
         <ThemeProvider>
-          <div className='App'>위키키</div>
+          <Outlet />
         </ThemeProvider>
       </QueryClientProvider>
     </RecoilRoot>

--- a/src/components/DividerWithText.tsx
+++ b/src/components/DividerWithText.tsx
@@ -10,7 +10,7 @@ const DividerWithText = ({ children }: DividerWithTextProps) => {
       <div className='absolute inset-0 flex items-center'>
         <div className='w-full border-t border-gray-200' />
       </div>
-      <div className='relative flex justify-center text-sm leading-6'>
+      <div className='relative flex justify-center text-xs leading-6'>
         <span className='bg-white px-2 text-gray-500'>{children}</span>
       </div>
     </div>

--- a/src/components/DividerWithText.tsx
+++ b/src/components/DividerWithText.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+interface DividerWithTextProps {
+  children: React.ReactNode;
+}
+
+const DividerWithText = ({ children }: DividerWithTextProps) => {
+  return (
+    <div className='relative'>
+      <div className='absolute inset-0 flex items-center'>
+        <div className='w-full border-t border-gray-200' />
+      </div>
+      <div className='relative flex justify-center text-sm leading-6'>
+        <span className='bg-white px-2 text-gray-500'>{children}</span>
+      </div>
+    </div>
+  );
+};
+
+export default DividerWithText;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,11 +4,18 @@ import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import App from './App';
 
 import './tailwind.css';
+import SignUpPage from './pages/SignUpPage';
 
 const router = createBrowserRouter([
   {
     path: '/',
     element: <App />,
+    children: [
+      {
+        path: '/signUp',
+        element: <SignUpPage />,
+      },
+    ],
   },
 ]);
 

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Button, Input } from '@material-tailwind/react';
+import { ReactComponent as TextLogo } from '../assets/images/logo/textLogo.svg';
+import DividerWithText from '../components/DividerWithText';
+
+const LoginPage = () => {
+  return (
+    <div className='flex min-h-full flex-col justify-center py-12 px-8'>
+      <div className='mx-auto space-y-4 w-full max-w-[600px] border border-gray-400 px-32 py-9'>
+        <TextLogo className='w-36 m-auto mb-8' data-testid='textLogo' />
+        <form className='space-y-12'>
+          <Input label='이메일' crossOrigin='' data-testid='email' />
+          <Input label='비밀번호' type='password' crossOrigin='' data-testid='password' />
+          <Button className='w-full' data-testid='signUpBtn'>
+            로그인
+          </Button>
+        </form>
+        <div className='text-center text-xs'>
+          {/* TODO 경로 지정 필요 */}
+          <Link to='/'>회원가입</Link> | <Link to='/'>비밀번호 찾기</Link>
+        </div>
+        <DividerWithText>다른 계정으로 로그인</DividerWithText>
+        {/* TODO 카카오톡 버튼으로 변경 필요 */}
+        <Button className='w-full' data-testid='kakaoLoginBtn'>
+          카카오톡으로 로그인
+        </Button>
+        {/* TODO 임시 로고 구성 아이콘 로고로 변경 필요 */}
+        <TextLogo className='w-36 m-auto' />
+      </div>
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const SignUpPage = () => {
+  return <div>SignUpPage</div>;
+};
+
+export default SignUpPage;

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -1,11 +1,17 @@
 import React from 'react';
+import { Input } from '@material-tailwind/react';
 import { ReactComponent as TextLogo } from '../assets/images/logo/textLogo.svg';
 
 const SignUpPage = () => {
   return (
     <div className='flex min-h-full flex-col justify-center py-12 px-8'>
-      <div className='mx-auto w-full max-w-[600px] border border-gray-400 px-32 py-9'>
+      <div className='mx-auto space-y-10 w-full max-w-[600px] border border-gray-400 px-32 py-9'>
         <TextLogo className='w-36 m-auto' data-testid='textLogo' />
+        <form className='space-y-8'>
+          <Input label='이메일' crossOrigin='' data-testid='email' />
+          <Input label='비밀번호' type='password' crossOrigin='' data-testid='password' />
+          <Input label='이름' crossOrigin='' data-testid='name' />
+        </form>
       </div>
     </div>
   );

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
+import { ReactComponent as TextLogo } from '../assets/images/logo/textLogo.svg';
 
 const SignUpPage = () => {
-  return <div>SignUpPage</div>;
+  return (
+    <div className='flex min-h-full flex-col justify-center py-12 px-8'>
+      <div className='mx-auto w-full max-w-[600px] border border-gray-400 px-32 py-9'>
+        <TextLogo className='w-36 m-auto' data-testid='textLogo' />
+      </div>
+    </div>
+  );
 };
 
 export default SignUpPage;

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -21,6 +21,8 @@ const SignUpPage = () => {
         <Button className='w-full' data-testid='kakaoSignUpBtn'>
           카카오톡으로 회원가입
         </Button>
+        {/* TODO 임시 로고 구성 아이콘 로고로 변경 필요 */}
+        <TextLogo className='w-36 m-auto' />
       </div>
     </div>
   );

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -1,17 +1,26 @@
 import React from 'react';
-import { Input } from '@material-tailwind/react';
+import { Button, Input } from '@material-tailwind/react';
 import { ReactComponent as TextLogo } from '../assets/images/logo/textLogo.svg';
+import DividerWithText from '../components/DividerWithText';
 
 const SignUpPage = () => {
   return (
     <div className='flex min-h-full flex-col justify-center py-12 px-8'>
-      <div className='mx-auto space-y-10 w-full max-w-[600px] border border-gray-400 px-32 py-9'>
-        <TextLogo className='w-36 m-auto' data-testid='textLogo' />
+      <div className='mx-auto space-y-4 w-full max-w-[600px] border border-gray-400 px-32 py-9'>
+        <TextLogo className='w-36 m-auto mb-8' data-testid='textLogo' />
         <form className='space-y-8'>
           <Input label='이메일' crossOrigin='' data-testid='email' />
           <Input label='비밀번호' type='password' crossOrigin='' data-testid='password' />
           <Input label='이름' crossOrigin='' data-testid='name' />
+          <Button className='w-full' data-testid='signUpBtn'>
+            회원가입
+          </Button>
         </form>
+        <DividerWithText>또는</DividerWithText>
+        {/* TODO 카카오톡 버튼으로 변경 필요 */}
+        <Button className='w-full' data-testid='kakaoSignUpBtn'>
+          카카오톡으로 회원가입
+        </Button>
       </div>
     </div>
   );

--- a/src/test/pages/SignUpPage.test.tsx
+++ b/src/test/pages/SignUpPage.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import SignUpPage from '../../pages/SignUpPage';
+
+describe('회원가입', () => {
+  describe('UI 컴포넌트 렌더링', () => {
+    it('텍스트 로고 렌더링 성공', () => {
+      render(<SignUpPage />);
+      const textLogoElement = screen.getByTestId('textLogo');
+
+      expect(textLogoElement).toBeInTheDocument();
+    });
+  });
+});

--- a/src/test/pages/SignUpPage.test.tsx
+++ b/src/test/pages/SignUpPage.test.tsx
@@ -28,5 +28,17 @@ describe('회원가입', () => {
 
       expect(nameInputElement).toBeInTheDocument();
     });
+    it('회원가입 버튼 렌더링 성공', () => {
+      render(<SignUpPage />);
+      const nameInputElement = screen.getByTestId('signUpBtn');
+
+      expect(nameInputElement).toBeInTheDocument();
+    });
+    it('카카오톡으로 회원가입 버튼 렌더링 성공', () => {
+      render(<SignUpPage />);
+      const nameInputElement = screen.getByTestId('kakaoSignUpBtn');
+
+      expect(nameInputElement).toBeInTheDocument();
+    });
   });
 });

--- a/src/test/pages/SignUpPage.test.tsx
+++ b/src/test/pages/SignUpPage.test.tsx
@@ -10,5 +10,23 @@ describe('회원가입', () => {
 
       expect(textLogoElement).toBeInTheDocument();
     });
+    it('이메일 인풋 렌더링 성공', () => {
+      render(<SignUpPage />);
+      const emailInputElement = screen.getByTestId('email');
+
+      expect(emailInputElement).toBeInTheDocument();
+    });
+    it('비밀번호 인풋 렌더링 성공', () => {
+      render(<SignUpPage />);
+      const passwordInputElement = screen.getByTestId('password');
+
+      expect(passwordInputElement).toBeInTheDocument();
+    });
+    it('이름 인풋 렌더링 성공', () => {
+      render(<SignUpPage />);
+      const nameInputElement = screen.getByTestId('name');
+
+      expect(nameInputElement).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
## ⭐Key Changes

회원가입, 로그인 페이지 UI 구성하였습니다.


## 📌Issue
- #23,  #28 


## 👪To Reviewers
- 회원가입, 로그인 구성이 비슷해서 한 PR로 날렸습니다!
- 카카오톡 회원가입/로그인의 경우 카카오 [디자인 가이드](https://developers.kakao.com/docs/latest/ko/kakaologin/design-guide)를 따라야 하더라구요. 제공해주는 거 바로 사용하려고 하니까 저희 UI와 규격등이 안 맞는 부분이 있어서 커스텀이 필요할 것 같아요. 시간 여유가 없어서 일단 기본 버튼으로 임시 구성해두었는데 추후 변경해두겠습니다.
- 로그인/회원가입 영역 하단에 아이콘 로고 사용해야하는데 #25 PR에서 아이콘 로고 추가된 상태라 일단 임시로 TextLogo로 넣어놨습니다. 해당 PR 머지되면 변경해두겠습니다.
- 로그인 페이지 라우터 구성도 #25에 있어서 일단 없이 진행하였습니다!
- 테스트 코드 작성할 때 아래와 같은 구성으로 해봤는데 괜찮을까요?
  - describe(페이지 이름)
    - describe(큰 단위 테스트)
      - describe(작은 단위 테스트)
- 회원가입 테스트 다 통과했습니다! Vv (로그인 테스트는 시간 부족 이슈로 아직 못했습니다...!)
  <img width="421" alt="image" src="https://github.com/Step3-kakao-tech-campus/Team8_FE/assets/78250089/0277813f-aec0-4ba2-9ad1-e541a1ff8215">


+) 추석 연휸데 다들 고생 많습니다...! 화이팅!!

## 💻Preview
|회원가입|로그인|
|------|------|
|<img width="664" alt="image" src="https://github.com/Step3-kakao-tech-campus/Team8_FE/assets/78250089/8b84fffc-b80a-40d0-8b95-48c13130fc54">|<img width="651" alt="image" src="https://github.com/Step3-kakao-tech-campus/Team8_FE/assets/78250089/ba1b93dc-64dd-4d8f-8525-256d36db6621">|


## 🐾Next Move
- 카카오톡으로 회원가입/로그인 버튼 디자인 가이드 따라 변경
- 아이콘 로고 머지되면 적용하기
- 로그인 테스트 코드 작성하기
