### PR TITLE
회원가입, 로그인 UI 보완

### DIFF
--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { RiKakaoTalkFill } from 'react-icons/ri';
 import { Button, Input } from '@material-tailwind/react';
 import { ReactComponent as TextLogo } from '@assets/images/logo/textLogo.svg';
 import DividerWithText from '@components/DividerWithText';
@@ -27,9 +28,15 @@ const LoginPage = () => {
           </Link>
         </div>
         <DividerWithText>다른 계정으로 로그인</DividerWithText>
-        {/* TODO 카카오톡 버튼으로 변경 필요 */}
-        <Button className='w-full' data-testid='kakaoLoginBtn'>
-          카카오톡으로 로그인
+        <Button
+          className='flex font-[system-ui] justify-center w-full rounded-xl items-center gap-2 bg-kakaoContainer text-kakaoLabel'
+          data-testid='kakaoLoginBtn'
+        >
+          <div className='relative w-5 h-5'>
+            <RiKakaoTalkFill size={20} className='absolute inset-0 m-auto fill-kakaoSymbol' />
+            <div className='absolute inset-0 m-auto bg-kakaoSymbol w-4 h-2 rounded-full' />
+          </div>
+          카카오 로그인
         </Button>
       </div>
     </div>

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -8,7 +8,7 @@ import DividerWithText from '@components/DividerWithText';
 const LoginPage = () => {
   return (
     <div className='flex min-h-full flex-col justify-center py-12 px-8'>
-      <div className='mx-auto space-y-4 w-full max-w-[600px] border border-gray-400 px-32 pt-9 pb-16'>
+      <div className='mx-auto shadow space-y-4 w-full max-w-[450px] px-16 pt-9 pb-16'>
         <TextLogo className='w-36 m-auto mb-8' data-testid='textLogo' />
         <form className='space-y-12'>
           <Input label='이메일' crossOrigin='' data-testid='email' />

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -7,7 +7,7 @@ import DividerWithText from '@components/DividerWithText';
 const LoginPage = () => {
   return (
     <div className='flex min-h-full flex-col justify-center py-12 px-8'>
-      <div className='mx-auto space-y-4 w-full max-w-[600px] border border-gray-400 px-32 py-9'>
+      <div className='mx-auto space-y-4 w-full max-w-[600px] border border-gray-400 px-32 pt-9 pb-16'>
         <TextLogo className='w-36 m-auto mb-8' data-testid='textLogo' />
         <form className='space-y-12'>
           <Input label='이메일' crossOrigin='' data-testid='email' />
@@ -25,8 +25,6 @@ const LoginPage = () => {
         <Button className='w-full' data-testid='kakaoLoginBtn'>
           카카오톡으로 로그인
         </Button>
-        {/* TODO 임시 로고 구성 아이콘 로고로 변경 필요 */}
-        <TextLogo className='w-36 m-auto' />
       </div>
     </div>
   );

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -12,13 +12,19 @@ const LoginPage = () => {
         <form className='space-y-12'>
           <Input label='이메일' crossOrigin='' data-testid='email' />
           <Input label='비밀번호' type='password' crossOrigin='' data-testid='password' />
-          <Button className='w-full' data-testid='signUpBtn'>
+          <Button className='w-full' data-testid='loginBtn'>
             로그인
           </Button>
         </form>
         <div className='text-center text-xs'>
           {/* TODO 경로 지정 필요 */}
-          <Link to='/'>회원가입</Link> | <Link to='/'>비밀번호 찾기</Link>
+          <Link to='/' data-testid='signUpLink'>
+            회원가입
+          </Link>
+          {` | `}
+          <Link to='/' data-testid='passwordFindLink'>
+            비밀번호 찾기
+          </Link>
         </div>
         <DividerWithText>다른 계정으로 로그인</DividerWithText>
         {/* TODO 카카오톡 버튼으로 변경 필요 */}

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -6,7 +6,7 @@ import DividerWithText from '@components/DividerWithText';
 const SignUpPage = () => {
   return (
     <div className='flex min-h-full flex-col justify-center py-12 px-8'>
-      <div className='mx-auto space-y-4 w-full max-w-[600px] border border-gray-400 px-32 py-9'>
+      <div className='mx-auto space-y-4 w-full max-w-[600px] border border-gray-400 px-32 pt-9 pb-16'>
         <TextLogo className='w-36 m-auto mb-8' data-testid='textLogo' />
         <form className='space-y-8'>
           <Input label='이메일' crossOrigin='' data-testid='email' />
@@ -21,8 +21,6 @@ const SignUpPage = () => {
         <Button className='w-full' data-testid='kakaoSignUpBtn'>
           카카오톡으로 회원가입
         </Button>
-        {/* TODO 임시 로고 구성 아이콘 로고로 변경 필요 */}
-        <TextLogo className='w-36 m-auto' />
       </div>
     </div>
   );

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import { Button, Input } from '@material-tailwind/react';
 import { ReactComponent as TextLogo } from '@assets/images/logo/textLogo.svg';
-import DividerWithText from '@components/DividerWithText';
 
 const SignUpPage = () => {
   return (
     <div className='flex min-h-full flex-col justify-center py-12 px-8'>
       <div className='mx-auto space-y-4 w-full max-w-[600px] border border-gray-400 px-32 pt-9 pb-16'>
         <TextLogo className='w-36 m-auto mb-8' data-testid='textLogo' />
-        <form className='space-y-8'>
+        <form className='space-y-12'>
           <Input label='이메일' crossOrigin='' data-testid='email' />
           <Input label='비밀번호' type='password' crossOrigin='' data-testid='password' />
           <Input label='이름' crossOrigin='' data-testid='name' />
@@ -16,11 +15,6 @@ const SignUpPage = () => {
             회원가입
           </Button>
         </form>
-        <DividerWithText>또는</DividerWithText>
-        {/* TODO 카카오톡 버튼으로 변경 필요 */}
-        <Button className='w-full' data-testid='kakaoSignUpBtn'>
-          카카오톡으로 회원가입
-        </Button>
       </div>
     </div>
   );

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -5,7 +5,7 @@ import { ReactComponent as TextLogo } from '@assets/images/logo/textLogo.svg';
 const SignUpPage = () => {
   return (
     <div className='flex min-h-full flex-col justify-center py-12 px-8'>
-      <div className='mx-auto space-y-4 w-full max-w-[600px] border border-gray-400 px-32 pt-9 pb-16'>
+      <div className='mx-auto space-y-4 w-full shadow max-w-[450px] px-16 pt-9 pb-16'>
         <TextLogo className='w-36 m-auto mb-8' data-testid='textLogo' />
         <form className='space-y-12'>
           <Input label='이메일' crossOrigin='' data-testid='email' />

--- a/src/test/pages/LoginPage.test.tsx
+++ b/src/test/pages/LoginPage.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import LoginPage from '@pages/LoginPage';
+import { BrowserRouter } from 'react-router-dom';
+
+describe('로그인', () => {
+  describe('UI 컴포넌트 렌더링', () => {
+    it('텍스트 로고 렌더링 성공', () => {
+      render(
+        <BrowserRouter>
+          <LoginPage />
+        </BrowserRouter>,
+      );
+
+      const textLogoElement = screen.getByTestId('textLogo');
+
+      expect(textLogoElement).toBeInTheDocument();
+    });
+    it('이메일 인풋 렌더링 성공', () => {
+      render(
+        <BrowserRouter>
+          <LoginPage />
+        </BrowserRouter>,
+      );
+
+      const emailInputElement = screen.getByTestId('email');
+
+      expect(emailInputElement).toBeInTheDocument();
+    });
+    it('비밀번호 인풋 렌더링 성공', () => {
+      render(
+        <BrowserRouter>
+          <LoginPage />
+        </BrowserRouter>,
+      );
+
+      const passwordInputElement = screen.getByTestId('password');
+
+      expect(passwordInputElement).toBeInTheDocument();
+    });
+    it('로그인 버튼 렌더링 성공', () => {
+      render(
+        <BrowserRouter>
+          <LoginPage />
+        </BrowserRouter>,
+      );
+
+      const loginBtnElement = screen.getByTestId('loginBtn');
+
+      expect(loginBtnElement).toBeInTheDocument();
+    });
+    it('회원가입 이동 링크 렌더링 성공', () => {
+      render(
+        <BrowserRouter>
+          <LoginPage />
+        </BrowserRouter>,
+      );
+
+      const signUpLinkElement = screen.getByTestId('signUpLink');
+
+      expect(signUpLinkElement).toBeInTheDocument();
+    });
+    it('비밀번호 찾기 이동 링크 렌더링 성공', () => {
+      render(
+        <BrowserRouter>
+          <LoginPage />
+        </BrowserRouter>,
+      );
+
+      const passwordFindLinkElement = screen.getByTestId('passwordFindLink');
+
+      expect(passwordFindLinkElement).toBeInTheDocument();
+    });
+    it('카카오톡으로 로그인 버튼 렌더링 성공', () => {
+      render(
+        <BrowserRouter>
+          <LoginPage />
+        </BrowserRouter>,
+      );
+
+      const kakaoLoginBtnElement = screen.getByTestId('kakaoLoginBtn');
+
+      expect(kakaoLoginBtnElement).toBeInTheDocument();
+    });
+  });
+});

--- a/src/test/pages/SignUpPage.test.tsx
+++ b/src/test/pages/SignUpPage.test.tsx
@@ -30,9 +30,9 @@ describe('회원가입', () => {
     });
     it('회원가입 버튼 렌더링 성공', () => {
       render(<SignUpPage />);
-      const nameInputElement = screen.getByTestId('signUpBtn');
+      const signUpBtnInputElement = screen.getByTestId('signUpBtn');
 
-      expect(nameInputElement).toBeInTheDocument();
+      expect(signUpBtnInputElement).toBeInTheDocument();
     });
   });
 });

--- a/src/test/pages/SignUpPage.test.tsx
+++ b/src/test/pages/SignUpPage.test.tsx
@@ -34,11 +34,5 @@ describe('회원가입', () => {
 
       expect(nameInputElement).toBeInTheDocument();
     });
-    it('카카오톡으로 회원가입 버튼 렌더링 성공', () => {
-      render(<SignUpPage />);
-      const nameInputElement = screen.getByTestId('kakaoSignUpBtn');
-
-      expect(nameInputElement).toBeInTheDocument();
-    });
   });
 });

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,7 +6,13 @@ const withMT = require('@material-tailwind/react/utils/withMT');
 module.exports = withMT({
   content: ['./src/**/*.{js,jsx,ts,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        kakaoContainer: '#FEE500',
+        kakaoSymbol: '#000000',
+        kakaoLabel: '#000000D9',
+      },
+    },
   },
   plugins: [],
 });


### PR DESCRIPTION
## ⭐Key Changes
- 틀 하단에 아이콘 로고 넣었을 때 푸터의 아이콘 로고와 중복되어 보여서 제거하였습니다.
- 카카오 로그인 버튼 최대한 [디자인 가이드](https://developers.kakao.com/docs/latest/ko/kakaologin/design-guide)에 맞춰서 넣어봤습니다. (카카오 회원가입은 제거했습니다.)
  - 가이드에서 제시하는 색상 알아보기 쉽도록 tailwindcss 색상으로 확장해서 적용하였습니다.
  - 심볼로 사용되는 글자없는 말풍선 아이콘 구하기 쉽지 않아서 react-icons(Remix Icon)의 카카오톡심볼에서 글자를 가려주는 방식으로 일단 처리했습니다.
  - 폰트의 경우 OS 별 기본 시스템 서체를 사용해야 한다고 하여 `system-ui` 폰트로 지정해주었습니다. chrome에서는 해당 폰트가 잘 적용되는 걸로 아는데 다른 브라우저는 어떤 지 확인이 필요할 것 같습니다.
  - radius 12px로 맞춰줬습니다.
- 기존에 border로 틀 테두리 넣어줬었는데 조금 부자연스러워 보여서 shadow로 변경했습니다.

## 📌Issue
- Close #23, Close #28

## 👪To Reviewers
- 렌더링 테스트 코드 과한가 싶긴 한데 뿌듯해서 하나하나 테스트 하는 중! 😆
  <img width="100" alt="image" src="https://github.com/Step3-kakao-tech-campus/Team8_FE/assets/78250089/e0e9a245-4cc0-4154-b1c4-8f24778e8f91"> <img width="100" alt="image" src="https://github.com/Step3-kakao-tech-campus/Team8_FE/assets/78250089/ce084df2-a8ec-4e39-8343-1e3e4e2e780c">
- 이번주 또 이것저것 바쁜게 몰아쳐서 늦어졌네용..! 🙇‍♂️ 다음주부터는 좀 더 빨리 빨리 한 번 해보겠습니당! 🔥

## Preview
**로그인 페이지**
|Before|After|
|------|-----|
|<img width="300" alt="image" src="https://github.com/Step3-kakao-tech-campus/Team8_FE/assets/78250089/cd15c42d-4ed1-492c-b95d-cb516d89901e">|<img width="300" alt="image" src="https://github.com/Step3-kakao-tech-campus/Team8_FE/assets/78250089/ee8094e6-9dcb-4034-91cf-6697907c7890">|

**회원가입 페이지**
|After|
|-----|
|<img width="300" alt="image" src="https://github.com/Step3-kakao-tech-campus/Team8_FE/assets/78250089/eae162b5-382f-4484-889a-a861082d461d">|

## 🐾Next Move
- 그룹 생성 UI도 거의 끝나가서 곧 PR 올릴 예정!
