### PR TITLE
그룹 검색 결과 페이지 UI 구현

### DIFF
--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -1,4 +1,4 @@
-import React, { useState, KeyboardEvent, ChangeEvent } from 'react';
+import React, { useState, KeyboardEvent } from 'react';
 import { List, ListItem, Card, Input } from '@material-tailwind/react';
 import { MdClear, MdSearch } from 'react-icons/md';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -12,16 +12,17 @@ const SearchInput = ({ isLoggedIn }: InputProps) => {
   const [searchBar, setSearchBar] = useState<string>('');
   const navigate = useNavigate();
 
-  const handleSearchBarChange = (e: ChangeEvent<HTMLInputElement>) => {
+  const handleSearchBarChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchBar(e.target.value);
   };
+
   const handleSearchBarClear = () => {
     setSearchBar('');
   };
   const handleSubmit = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
+    if (e.key === 'Enter' && searchBar && e.nativeEvent.isComposing === false) {
       navigate(groupName ? `${groupName}/search?keyword=${searchBar}` : `/search/group?keyword=${searchBar}`);
-      // console.log(searchBar);
+      setSearchBar('');
     }
   };
 

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -1,7 +1,7 @@
 import React, { useState, KeyboardEvent, ChangeEvent } from 'react';
 import { List, ListItem, Card, Input } from '@material-tailwind/react';
 import { MdClear, MdSearch } from 'react-icons/md';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 interface InputProps {
   isLoggedIn: boolean;
@@ -10,6 +10,7 @@ interface InputProps {
 const SearchInput = ({ isLoggedIn }: InputProps) => {
   const { groupName } = useParams();
   const [searchBar, setSearchBar] = useState<string>('');
+  const navigate = useNavigate();
 
   const handleSearchBarChange = (e: ChangeEvent<HTMLInputElement>) => {
     setSearchBar(e.target.value);
@@ -19,6 +20,7 @@ const SearchInput = ({ isLoggedIn }: InputProps) => {
   };
   const handleSubmit = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
+      navigate(groupName ? `${groupName}/search?keyword=${searchBar}` : `/search/group?keyword=${searchBar}`);
       // console.log(searchBar);
     }
   };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,6 +11,7 @@ import LoginPage from '@pages/LoginPage';
 import SignUpPage from '@pages/SignUpPage';
 import MyPage from '@pages/MyPage';
 import SearchResultPage from '@pages/SearchResultPage';
+import GroupSearchResultPage from '@pages/GroupSearchResultPage';
 
 import App from './App';
 
@@ -44,8 +45,12 @@ const router = createBrowserRouter([
         element: <MyPage />,
       },
       {
-        path: '/search',
+        path: '/:groupName/search',
         element: <SearchResultPage />,
+      },
+      {
+        path: '/search/group',
+        element: <GroupSearchResultPage />,
       },
     ],
   },

--- a/src/pages/GroupSearchResultPage.tsx
+++ b/src/pages/GroupSearchResultPage.tsx
@@ -18,7 +18,7 @@ const GroupSearchResultPage = () => {
       <h1 className='mb-8'>
         &apos;<span className='text-xl font-bold'>{keyword}</span>&apos;에 대한 검색 결과입니다.
       </h1>
-      <div className='flex gap-2'>
+      <div className='flex gap-2 h-9'>
         <Button
           variant={isOfficialGroup ? 'filled' : 'outlined'}
           size='sm'

--- a/src/pages/GroupSearchResultPage.tsx
+++ b/src/pages/GroupSearchResultPage.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import { Button } from '@material-tailwind/react';
+import GroupList from '@components/GroupList';
+import { officialGroupDummyData, unOfficialGroupDummyData } from '@dummy/group';
+import { useSearchParams } from 'react-router-dom';
+
+const GroupSearchResultPage = () => {
+  const [isOfficialGroup, setIsOfficialGroup] = useState<boolean>(true);
+  const [searchParam] = useSearchParams();
+  const keyword = searchParam.get('keyword') || '테스트 키워드';
+
+  return (
+    <section className='max-w-3xl min-w-max mx-auto my-40'>
+      <h1 className='mb-8'>
+        &apos;<span className='text-xl font-bold'>{keyword}</span>&apos;에 대한 검색 결과입니다.
+      </h1>
+      <div className='flex gap-2'>
+        <Button
+          variant={isOfficialGroup ? 'filled' : 'outlined'}
+          size='sm'
+          color='gray'
+          ripple={false}
+          className='rounded-full font-nanum'
+          onClick={() => setIsOfficialGroup(true)}
+        >
+          공식 그룹
+        </Button>
+        <Button
+          variant={isOfficialGroup ? 'outlined' : 'filled'}
+          size='sm'
+          color='gray'
+          ripple={false}
+          className='rounded-full font-nanum'
+          onClick={() => setIsOfficialGroup(false)}
+        >
+          비공식 그룹
+        </Button>
+      </div>
+      <GroupList groups={isOfficialGroup ? officialGroupDummyData : unOfficialGroupDummyData} />
+    </section>
+  );
+};
+
+export default GroupSearchResultPage;

--- a/src/pages/GroupSearchResultPage.tsx
+++ b/src/pages/GroupSearchResultPage.tsx
@@ -1,13 +1,17 @@
 import React, { useState } from 'react';
 import { Button } from '@material-tailwind/react';
 import GroupList from '@components/GroupList';
+// import { nullGroupDummyData } from '@dummy/group';
 import { officialGroupDummyData, unOfficialGroupDummyData } from '@dummy/group';
-import { useSearchParams } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
+import { MdChevronRight } from 'react-icons/md';
 
 const GroupSearchResultPage = () => {
   const [isOfficialGroup, setIsOfficialGroup] = useState<boolean>(true);
   const [searchParam] = useSearchParams();
   const keyword = searchParam.get('keyword') || '테스트 키워드';
+  const groupData = isOfficialGroup ? officialGroupDummyData : unOfficialGroupDummyData;
+  // const groupData = nullGroupDummyData;
 
   return (
     <section className='max-w-3xl min-w-max mx-auto my-40'>
@@ -36,7 +40,17 @@ const GroupSearchResultPage = () => {
           비공식 그룹
         </Button>
       </div>
-      <GroupList groups={isOfficialGroup ? officialGroupDummyData : unOfficialGroupDummyData} />
+      {groupData.length === 0 ? (
+        <div className='flex flex-col items-center justify-center h-[300px]'>
+          <h1 className='mb-2 text-xl font-bold'>관련된 그룹이 없어요.</h1>
+          <Link to='/groupCreate' className='mt-2 text-sm text-gray-400 hover:text-blue-300'>
+            <span>새로운 그룹 만들러 가기</span>
+            <MdChevronRight className='inline-block' width={15} height={15} />
+          </Link>
+        </div>
+      ) : (
+        <GroupList groups={groupData} />
+      )}
     </section>
   );
 };


### PR DESCRIPTION

![image](https://github.com/Step3-kakao-tech-campus/Team8_FE/assets/48706964/53d15bd6-65cf-44fb-9bba-b95c33c2c746)


## ⭐Key Changes
> 핵심 변경 사항에 대해서 적어주세요.
1. 그룹 검색 결과 페이지의 UI 구현
2. 헤더 검색창과 연결
3. 라우터 주소 수정

<br>

## 📌Issue
> "close #이슈번호"로 해당 이슈 완료해주세요.
- Close #38 

<br>

## 👪To Reviewers
> reviewer에게 하고 싶은 말을 적어주세요.

그룹 검색 결과 API에서 내려오는 정보가 그냥 그룹 필드랑 동일해서(안내나 설명글 없음) 만들어둔 컴포넌트 재사용하여 출력하는 것으로 처리했습니다.
개인적으로 저 멘트 '~에 대한 검색 결과입니다' 가 마음에 안 들어서 고민 좀 더 해보고 나중에 같이 수정 해보겠습니다... ㅎㅎ... 
@GangHub1970 검색창에서 검색하면 결과 페이지로 가도록 조금 손댔습니다!


<br>

## 🐾Next Move
> 다음 개발 목표를 적어주세요

홈페이지에서 처리하지 않았던 부분 수정하겠습니다!
그리고 가능하다면 그룹 리스트 컴포넌트 디자인도 조금 고치고 싶은데... 더 나은게 안 보이면 일단 그대로 두겠습니다