### PR TITLE
Feature/페이지 내부 공통 컨테이너

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,9 +20,7 @@ const App = () => {
       <QueryClientProvider client={queryClient}>
         <ThemeProvider>
           <Header />
-          <div className='max-w-3xl min-w-max mx-auto mt-[59px] pt-20 pb-12'>
-            <Outlet />
-          </div>
+          <Outlet />
           <Footer />
         </ThemeProvider>
       </QueryClientProvider>

--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+
+const MainLayout = () => {
+  return (
+    <div className='max-w-3xl min-w-max mx-auto mt-[59px] pt-20 pb-12'>
+      <Outlet />
+    </div>
+  );
+};
+
+export default MainLayout;

--- a/src/components/PageContainer.tsx
+++ b/src/components/PageContainer.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+interface PageContainerProps {
+  children: React.ReactNode;
+}
+
+const PageContainer = ({ children }: PageContainerProps) => {
+  return (
+    <div className='mx-auto flex w-full max-w-full flex-col xl:flex-row items-start justify-center gap-4 xl:gap-6 2xl:gap-10 px-8 py-10'>
+      <aside className='sticky w-full top-8 xl:w-52 2xl:w-64 shrink-0'>{/* 목차 */}</aside>
+      <main className='w-full xl:max-w-4xl'>{children}</main>
+      <aside className='sticky top-8 w-full xl:w-52 2xl:w-64 shrink-0'>{/* 최근 변경 */}</aside>
+    </div>
+  );
+};
+
+export default PageContainer;

--- a/src/components/PageContainer.tsx
+++ b/src/components/PageContainer.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import RecentChangeList from './RecentChangeList';
 
 interface PageContainerProps {
   children: React.ReactNode;
@@ -7,9 +8,11 @@ interface PageContainerProps {
 const PageContainer = ({ children }: PageContainerProps) => {
   return (
     <div className='mx-auto flex w-full max-w-full flex-col xl:flex-row items-start justify-center gap-4 xl:gap-6 2xl:gap-10 px-8 py-10'>
-      <aside className='sticky w-full top-8 xl:w-52 2xl:w-64 shrink-0'>{/* 목차 */}</aside>
+      <aside className='sticky w-full top-20 xl:w-52 2xl:w-64 shrink-0'>{/* 목차 */}</aside>
       <main className='w-full xl:max-w-4xl'>{children}</main>
-      <aside className='sticky top-8 w-full xl:w-52 2xl:w-64 shrink-0'>{/* 최근 변경 */}</aside>
+      <aside className='sticky top-20 w-full xl:w-52 2xl:w-64 shrink-0'>
+        <RecentChangeList />
+      </aside>
     </div>
   );
 };

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+
+const PageLayout = () => {
+  return (
+    <div className='mx-auto mt-[59px] pt-20 pb-12'>
+      <Outlet />
+    </div>
+  );
+};
+
+export default PageLayout;

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -3,7 +3,7 @@ import { Outlet } from 'react-router-dom';
 
 const PageLayout = () => {
   return (
-    <div className='mx-auto mt-[59px] pt-20 pb-12'>
+    <div className='2xl:mx-20 mt-[59px] pt-20 pb-12'>
       <Outlet />
     </div>
   );

--- a/src/components/PageTitleSection.tsx
+++ b/src/components/PageTitleSection.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+interface PageTitleSectionProps {
+  title: string;
+  aboveAdornment?: React.ReactNode;
+  underAdornment?: React.ReactNode;
+}
+
+const PageTitleSection = ({ title, aboveAdornment, underAdornment }: PageTitleSectionProps) => {
+  return (
+    <section className='w-full flex flex-col justify-center max-w-full px-8'>
+      <div className='mx-20'>
+        <div className='px-2 border-b-2 flex mb-2'>
+          <h1 className='text-4xl leading-normal font-semibold text-start'>{title}</h1>
+          {aboveAdornment}
+        </div>
+        {underAdornment}
+      </div>
+    </section>
+  );
+};
+
+export default PageTitleSection;

--- a/src/components/PageTitleSection.tsx
+++ b/src/components/PageTitleSection.tsx
@@ -11,7 +11,7 @@ const PageTitleSection = ({ title, aboveAdornment, underAdornment }: PageTitleSe
     <section className='w-full flex flex-col justify-center max-w-full px-8'>
       <div>
         <div className='px-2 border-b-2 flex mb-2'>
-          <h1 className='text-4xl leading-normal font-semibold text-start'>{title}</h1>
+          <h1 className='text-4xl leading-normal font-semibold max-w-fit w-full truncate'>{title}</h1>
           {aboveAdornment}
         </div>
         {underAdornment}

--- a/src/components/PageTitleSection.tsx
+++ b/src/components/PageTitleSection.tsx
@@ -9,7 +9,7 @@ interface PageTitleSectionProps {
 const PageTitleSection = ({ title, aboveAdornment, underAdornment }: PageTitleSectionProps) => {
   return (
     <section className='w-full flex flex-col justify-center max-w-full px-8'>
-      <div className='2xl:mx-20'>
+      <div>
         <div className='px-2 border-b-2 flex mb-2'>
           <h1 className='text-4xl leading-normal font-semibold text-start'>{title}</h1>
           {aboveAdornment}

--- a/src/components/PageTitleSection.tsx
+++ b/src/components/PageTitleSection.tsx
@@ -9,7 +9,7 @@ interface PageTitleSectionProps {
 const PageTitleSection = ({ title, aboveAdornment, underAdornment }: PageTitleSectionProps) => {
   return (
     <section className='w-full flex flex-col justify-center max-w-full px-8'>
-      <div className='mx-20'>
+      <div className='2xl:mx-20'>
         <div className='px-2 border-b-2 flex mb-2'>
           <h1 className='text-4xl leading-normal font-semibold text-start'>{title}</h1>
           {aboveAdornment}

--- a/src/components/RecentChangeList.tsx
+++ b/src/components/RecentChangeList.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 const RecentChangeList = () => {
   return (
-    <div className='w-44'>
+    <div className='w-full'>
       <h2 className='font-bold px-1 py-2'>최근 변경된 페이지</h2>
       <ul className='p-4 bg-gray-100 text-sm'>
         {recentChangePageDummyData.map((page) => (

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,6 +15,8 @@ import SearchResultPage from '@pages/SearchResultPage';
 import GroupSearchResultPage from '@pages/GroupSearchResultPage';
 import GroupCreatePage from '@pages/GroupCreatePage';
 
+import MainLayout from '@components/MainLayout';
+import PageLayout from '@components/PageLayout';
 import App from './App';
 
 const router = createBrowserRouter([
@@ -23,44 +25,54 @@ const router = createBrowserRouter([
     element: <App />,
     children: [
       {
-        index: true,
-        element: <HomePage />,
+        element: <MainLayout />,
+        children: [
+          {
+            index: true,
+            element: <HomePage />,
+          },
+          {
+            path: '/:groupName/myPage',
+            element: <GroupMyPage />,
+          },
+          {
+            path: '/:groupName/myPage/contribute',
+            element: <MyContributePage />,
+          },
+          {
+            path: '/login',
+            element: <LoginPage />,
+          },
+          {
+            path: '/signUp',
+            element: <SignUpPage />,
+          },
+          {
+            path: '/myPage',
+            element: <MyPage />,
+          },
+          {
+            path: '/:groupName/search',
+            element: <SearchResultPage />,
+          },
+          {
+            path: '/search/group',
+            element: <GroupSearchResultPage />,
+          },
+          {
+            path: '/groupCreate',
+            element: <GroupCreatePage />,
+          },
+        ],
       },
       {
-        path: '/:groupName',
-        element: <GroupMainPage />,
-      },
-      {
-        path: '/:groupName/myPage',
-        element: <GroupMyPage />,
-      },
-      {
-        path: '/:groupName/myPage/contribute',
-        element: <MyContributePage />,
-      },
-      {
-        path: '/login',
-        element: <LoginPage />,
-      },
-      {
-        path: '/signUp',
-        element: <SignUpPage />,
-      },
-      {
-        path: '/myPage',
-        element: <MyPage />,
-      },
-      {
-        path: '/:groupName/search',
-        element: <SearchResultPage />,
-      },
-      {
-        path: '/search/group',
-        element: <GroupSearchResultPage />,
-      },
-      {
-        path: '/groupCreate',
-        element: <GroupCreatePage />,
+        element: <PageLayout />,
+        children: [
+          {
+            path: '/:groupName',
+            element: <GroupMainPage />,
+          },
+        ],
       },
     ],
   },


### PR DESCRIPTION
## ⭐Key Changes

1. 좌측 사이드에 목차, 최근 변경 페이지로 구성된 컴포넌트 만들었습니다.
2. 기존에 적용되어 있던 레이아웃으로는 넓이가 맞지 않아 새로운 레이아웃 만들어 주고, 라우터에서 감싸주었습니다.
3. 페이지 제목 부분 컴포넌트도 만들었습니다.
4. 살짝 반응형도 적용해보았습니다.

## 📌Issue
- Close #68 


## 👪To Reviewers
- 일단 다른 분들도 써야하니 빨리 올리려고 목차는 일단 빼고 진행했습니다! 다음 이슈에서 같이 처리할게용! 그래서 왼쪽 영역은 잡히지만 비어있을 겁니다!
- 반응형! 제가 개발할 때 모니터 반 화면 띄워놓고 개발 많이해서 보기에 불편하지 않도록 이부분은 반응형도 미리 적용해봤습니다!
- 레이아웃 라우터로 옮긴 후에 다른 페이지들도 기존 레이아웃으로 잘 적용되는 거 확인했습니다!
- `PageTitleSection`에서 `aboveAdornment`로 밑줄 상단 부분 요소 구성할 수 있도록 하였고, `underAdornment`로 밑줄 아래부분 구성할 수 있도록 처리했습니다!


## Preview

(영상 용량 줄인다고 화질이 조금 안 좋을 수 있습니다!)

https://github.com/Step3-kakao-tech-campus/Team8_FE/assets/78250089/a01bb98b-db04-4e1a-a8b2-6f593974a1e1

https://github.com/Step3-kakao-tech-campus/Team8_FE/assets/78250089/60b6c7f8-63d5-4c4c-84ca-6a527a7a2d75

```tsx
const Example = () => {
  return (
    <div>
      <PageTitleSection
        title='페이지 제목'
        aboveAdornment={
          <div className='flex justify-between items-end w-full'>
            <Button variant='text'>[편집]</Button>
            <Button variant='text'>그룹원</Button>
          </div>
        }
        underAdornment={
          <div className='flex justify-end gap-2 w-full'>
            <Chip value='좋아요' />
            <Chip value='싫어요' />
          </div>
        }
      />
      <PageContainer>페이지 내용</PageContainer>
    </div>
  );
};

export default Example;
```





## 🐾Next Move
- #69 이슈 이어서 진행 예정입니다!
