### PR TITLE
Feature/페이지 조회 주요 UI 구성

### DIFF
--- a/src/components/IndexList.tsx
+++ b/src/components/IndexList.tsx
@@ -1,0 +1,29 @@
+import { getIndexList } from '@dummy/page';
+import React from 'react';
+
+interface IndexListProps {
+  pageId: number;
+}
+
+const IndexList = ({ pageId }: IndexListProps) => {
+  const indexList = getIndexList(pageId);
+
+  const getIndexDepth = (index: string) => {
+    return index.split('.').length - 1;
+  };
+
+  return (
+    <div className='w-full'>
+      <h2 className='font-bold px-1 py-2'>목차</h2>
+      <ul className='p-4 bg-gray-100 text-sm'>
+        {indexList.map((post) => (
+          <li key={post.index} className='my-2 leading-tight whitespace-pre'>
+            {' '.repeat(getIndexDepth(post.index))} {post.index} {post.postTitle}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default IndexList;

--- a/src/components/PageContainer.tsx
+++ b/src/components/PageContainer.tsx
@@ -1,14 +1,20 @@
 import React from 'react';
 import RecentChangeList from './RecentChangeList';
+import IndexList from './IndexList';
 
 interface PageContainerProps {
   children: React.ReactNode;
+  pageId?: number;
 }
 
-const PageContainer = ({ children }: PageContainerProps) => {
+const PageContainer = ({ children, pageId }: PageContainerProps) => {
   return (
     <div className='mx-auto flex w-full max-w-full flex-col xl:flex-row items-start justify-center gap-4 xl:gap-6 2xl:gap-10 px-8 py-10'>
-      <aside className='sticky w-full top-20 xl:w-52 2xl:w-64 shrink-0'>{/* 목차 */}</aside>
+      {pageId && (
+        <aside className='sticky w-full top-20 xl:w-52 2xl:w-64 shrink-0'>
+          <IndexList pageId={pageId} />
+        </aside>
+      )}
       <main className='w-full xl:max-w-4xl'>{children}</main>
       <aside className='sticky top-20 w-full xl:w-52 2xl:w-64 shrink-0'>
         <RecentChangeList />

--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+interface ViewerProps {
+  content: string;
+}
+
+/* TODO 추후 ck editor에 맞게 변경 필요 */
+const Viewer = ({ content }: ViewerProps) => {
+  return <div className='mb-8'>{content}</div>;
+};
+
+export default Viewer;

--- a/src/dummy/page.ts
+++ b/src/dummy/page.ts
@@ -42,8 +42,8 @@ interface PageInfo {
   badCount: number;
 }
 
-export const pageInfo: PageInfo = {
-  pageName: '부산대학교',
+export const getPageInfo = (groupName: string): PageInfo => ({
+  pageName: groupName,
   postList: [
     {
       postId: 1,
@@ -66,4 +66,4 @@ export const pageInfo: PageInfo = {
   ],
   goodCount: 7326,
   badCount: 545,
-};
+});

--- a/src/dummy/page.ts
+++ b/src/dummy/page.ts
@@ -1,9 +1,10 @@
 interface Page {
   pageId: number;
   pageName: string;
+  content: string;
 }
 
-export const recentChangePageDummyData: Page[] = [
+export const recentChangePageDummyData: Omit<Page, 'content'>[] = [
   { pageId: 1, pageName: '최근 변경 페이지 테스트' },
   { pageId: 2, pageName: '페이지 이름2' },
   { pageId: 3, pageName: '페이지 이름3' },
@@ -11,24 +12,58 @@ export const recentChangePageDummyData: Page[] = [
 
 interface Post {
   postId: number;
-  postName: string;
+  postTitle: string;
   content: string;
+  index: string;
 }
 
-export const postDummyData: Post[] = [
+export const pageDummyData: Page[] = [
   {
-    postId: 1,
-    postName: '테스트 게시글',
+    pageId: 1,
+    pageName: '테스트 게시글',
     content: '테스트 게시글 내용',
   },
   {
-    postId: 2,
-    postName: '테스트 게시글2',
+    pageId: 2,
+    pageName: '테스트 게시글2',
     content: '테스트 게시글 내용2',
   },
   {
-    postId: 3,
-    postName: '테스트 게시글3',
+    pageId: 3,
+    pageName: '테스트 게시글3',
     content: '테스트 게시글 내용3',
   },
 ];
+
+interface PageInfo {
+  pageName: string;
+  postList: Post[];
+  goodCount: number;
+  badCount: number;
+}
+
+export const pageInfo: PageInfo = {
+  pageName: '부산대학교',
+  postList: [
+    {
+      postId: 1,
+      index: '1',
+      postTitle: '개요',
+      content: '내용...',
+    },
+    {
+      postId: 2,
+      index: '2',
+      postTitle: '역사',
+      content: '내용...',
+    },
+    {
+      postId: 4,
+      index: '2-1',
+      postTitle: '컴공의 역사',
+      content: '내용...',
+    },
+  ],
+  goodCount: 7326,
+  badCount: 545,
+};

--- a/src/dummy/page.ts
+++ b/src/dummy/page.ts
@@ -59,7 +59,7 @@ export const getPageInfo = (groupName: string): PageInfo => ({
     },
     {
       postId: 4,
-      index: '2-1',
+      index: '2.1',
       postTitle: '컴공의 역사',
       content: '내용...',
     },

--- a/src/dummy/page.ts
+++ b/src/dummy/page.ts
@@ -37,6 +37,7 @@ export const pageDummyData: Page[] = [
 
 interface PageInfo {
   pageName: string;
+  pageId: number;
   postList: Post[];
   goodCount: number;
   badCount: number;
@@ -44,6 +45,7 @@ interface PageInfo {
 
 export const getPageInfo = (groupName: string): PageInfo => ({
   pageName: groupName,
+  pageId: 1,
   postList: [
     {
       postId: 1,
@@ -67,3 +69,19 @@ export const getPageInfo = (groupName: string): PageInfo => ({
   goodCount: 7326,
   badCount: 545,
 });
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const getIndexList = (pageId: number): Pick<Post, 'index' | 'postTitle'>[] => [
+  {
+    index: '1',
+    postTitle: '개요',
+  },
+  {
+    index: '2',
+    postTitle: '역사',
+  },
+  {
+    index: '2.1',
+    postTitle: '컴공의 역사',
+  },
+];

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -69,7 +69,7 @@ const router = createBrowserRouter([
         element: <PageLayout />,
         children: [
           {
-            path: '/:groupName',
+            path: '/:groupName/:page?',
             element: <GroupMainPage />,
           },
         ],

--- a/src/pages/GroupMainPage.tsx
+++ b/src/pages/GroupMainPage.tsx
@@ -16,7 +16,7 @@ const GroupMainPage = () => {
   return (
     <div>
       <PageTitleSection title={pageInfo.pageName} />
-      <PageContainer>
+      <PageContainer pageId={pageInfo.pageId}>
         {pageInfo.postList.map((post) => (
           <article>
             <div className='border-b-2 mb-4'>

--- a/src/pages/GroupMainPage.tsx
+++ b/src/pages/GroupMainPage.tsx
@@ -1,10 +1,21 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
 
+import PageTitleSection from '@components/PageTitleSection';
+import { getPageInfo } from '@dummy/page';
+
 const GroupMainPage = () => {
   const { groupName } = useParams();
 
-  return <div>{groupName}</div>;
+  if (!groupName) return null;
+
+  const pageInfo = getPageInfo(groupName);
+
+  return (
+    <div>
+      <PageTitleSection title={pageInfo.pageName} />
+    </div>
+  );
 };
 
 export default GroupMainPage;

--- a/src/pages/GroupMainPage.tsx
+++ b/src/pages/GroupMainPage.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
 
-import PageTitleSection from '@components/PageTitleSection';
 import { getPageInfo } from '@dummy/page';
+import PageTitleSection from '@components/PageTitleSection';
+import PageContainer from '@components/PageContainer';
+import Viewer from '@components/Viewer';
 
 const GroupMainPage = () => {
   const { groupName } = useParams();
@@ -14,6 +16,18 @@ const GroupMainPage = () => {
   return (
     <div>
       <PageTitleSection title={pageInfo.pageName} />
+      <PageContainer>
+        {pageInfo.postList.map((post) => (
+          <article>
+            <div className='border-b-2 mb-4'>
+              <h2 className='text-3xl leading-normal font-semibold'>
+                {post.index} {post.postTitle}
+              </h2>
+            </div>
+            <Viewer content={post.content} />
+          </article>
+        ))}
+      </PageContainer>
     </div>
   );
 };

--- a/src/pages/GroupMainPage.tsx
+++ b/src/pages/GroupMainPage.tsx
@@ -7,11 +7,11 @@ import PageContainer from '@components/PageContainer';
 import Viewer from '@components/Viewer';
 
 const GroupMainPage = () => {
-  const { groupName } = useParams();
+  const { groupName, page } = useParams();
 
   if (!groupName) return null;
 
-  const pageInfo = getPageInfo(groupName);
+  const pageInfo = getPageInfo(page ?? groupName);
 
   return (
     <div>

--- a/src/pages/SearchResultPage.tsx
+++ b/src/pages/SearchResultPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import RecentChangeList from '@components/RecentChangeList';
 import { MdArrowCircleRight } from 'react-icons/md';
-import { postDummyData } from '@dummy/page';
+import { pageDummyData } from '@dummy/page';
 
 const SearchResultPage = () => {
   const keyword = '테스트 검색어';
@@ -18,15 +18,15 @@ const SearchResultPage = () => {
               <MdArrowCircleRight className='w-5 h-5' />
             </div>
           </div>
-          {postDummyData.length === 0 ? (
+          {pageDummyData.length === 0 ? (
             <div className='flex flex-col items-center justify-center h-96'>
               <span className='text-xl font-bold mb-4'>검색 결과가 없습니다.</span>
               <span>다른 검색어로 검색하거나 직접 페이지를 만들어보세요.</span>
             </div>
           ) : (
-            postDummyData.map((post) => (
-              <div key={post.postId} className='px-2 py-8 border-b border-gray-200'>
-                <h2 className='text-lg font-bold mb-1'>{post.postName}</h2>
+            pageDummyData.map((post) => (
+              <div key={post.pageId} className='px-2 py-8 border-b border-gray-200'>
+                <h2 className='text-lg font-bold mb-1'>{post.pageName}</h2>
                 <p className='text-sm text-gray-500'>{post.content}</p>
               </div>
             ))


### PR DESCRIPTION
## ⭐Key Changes
- 페이지 제목, 내용, 목차 구성 해주었습니다.
- 목차의 경우 하위로 가면 들여쓰기 되도록 처리하였습니다.
- 목차 정보를 띄워주기 위해 `PageContainer`에 `pageId` props 추가하였습니다.
- 더미 데이터 api 응답 양식에 맞춘 수정 있었습니다.

## 📌Issue
-  Close #69

## 👪To Reviewers
-  다음주 수요일까지는... 더 바쁠 것 같아요 🥹
- 여유가 없으니 테스트 코드 자꾸 미루게 되네요 ㅠ

## Preview
https://github.com/Step3-kakao-tech-campus/Team8_FE/assets/78250089/5dcfe2aa-84c8-48e7-b0bd-b9276048385c
