### PR TITLE
페이지 조회 UI 버튼

### DIFF
--- a/src/components/AddPostButton.tsx
+++ b/src/components/AddPostButton.tsx
@@ -7,7 +7,7 @@ const AddPostButton = () => {
   const [isSplit, setIsSplit] = useState(false);
 
   const handleButtonClick = () => {
-    setIsSplit(!isSplit);
+    setIsSplit((prev) => !prev);
   };
 
   return (

--- a/src/components/AddPostButton.tsx
+++ b/src/components/AddPostButton.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+
+import { MdAddCircleOutline } from 'react-icons/md';
+import { Button, ButtonGroup } from '@material-tailwind/react';
+
+const AddPostButton = () => {
+  const [isSplit, setIsSplit] = useState(false);
+
+  const handleButtonClick = () => {
+    setIsSplit(!isSplit);
+  };
+
+  return (
+    <div className='flex items-center justify-center mb-4 '>
+      <Button
+        fullWidth
+        className={`h-10 bg-gray-50 text-white hover:text-gray-400 shadow-none rounded-sm transition-all duration-300 ease-in-out p-0 ${
+          isSplit ? 'w-0' : 'w-full'
+        }`}
+        onClick={handleButtonClick}
+      >
+        <MdAddCircleOutline size={22} className='mx-auto' />
+      </Button>
+      {isSplit && (
+        <ButtonGroup color='white' fullWidth className='shadow-none border-gray-300 rounded-sm h-10'>
+          <Button className='bg-gray-50 text-gray-500 rounded-sm'>다음 목차로 추가</Button>
+          <Button className='bg-gray-50 text-gray-500 rounded-sm'>하위 목차로 추가</Button>
+        </ButtonGroup>
+      )}
+    </div>
+  );
+};
+
+export default AddPostButton;

--- a/src/components/CommentList.tsx
+++ b/src/components/CommentList.tsx
@@ -28,7 +28,7 @@ const CommentList = ({ commentRef, isOpen, onCommentClose, comments }: CommentLi
   };
 
   return (
-    <Collapse open={isOpen} ref={commentRef} className='relative mb-12'>
+    <Collapse open={isOpen} ref={commentRef} className='relative mb-4'>
       <button type='button' className='absolute top-4 right-4' onClick={onCommentClose}>
         <MdOutlineKeyboardArrowUp className='text-xl' />
       </button>

--- a/src/components/LikeDislikeButton.tsx
+++ b/src/components/LikeDislikeButton.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import { Button } from '@material-tailwind/react';
+import { MdThumbDown, MdThumbUp } from 'react-icons/md';
+
+interface LikeDislikeButtonProps {
+  upCount: number;
+  downCount: number;
+}
+
+const LikeDislikeButton = ({ upCount, downCount }: LikeDislikeButtonProps) => {
+  return (
+    <div className='flex gap-2 h-7'>
+      <Button size='sm' ripple={false} className='rounded-full py-0 flex items-center gap-1 hover:animate-bounce'>
+        <MdThumbUp />
+        {upCount}
+      </Button>
+      <Button
+        color='white'
+        size='sm'
+        ripple={false}
+        className='rounded-full py-0 flex items-center gap-1 border hover:animate-bounce'
+      >
+        <MdThumbDown />
+        {downCount}
+      </Button>
+    </div>
+  );
+};
+
+export default LikeDislikeButton;

--- a/src/components/LikeDislikeButton.tsx
+++ b/src/components/LikeDislikeButton.tsx
@@ -11,16 +11,11 @@ interface LikeDislikeButtonProps {
 const LikeDislikeButton = ({ upCount, downCount }: LikeDislikeButtonProps) => {
   return (
     <div className='flex gap-2 h-7'>
-      <Button size='sm' ripple={false} className='rounded-full py-0 flex items-center gap-1 hover:animate-bounce'>
+      <Button size='sm' className='rounded-full py-0 flex items-center gap-1'>
         <MdThumbUp />
         {upCount}
       </Button>
-      <Button
-        color='white'
-        size='sm'
-        ripple={false}
-        className='rounded-full py-0 flex items-center gap-1 border hover:animate-bounce'
-      >
+      <Button color='white' size='sm' className='rounded-full py-0 flex items-center gap-1 border'>
         <MdThumbDown />
         {downCount}
       </Button>

--- a/src/components/PageTitleSection.tsx
+++ b/src/components/PageTitleSection.tsx
@@ -9,13 +9,11 @@ interface PageTitleSectionProps {
 const PageTitleSection = ({ title, aboveAdornment, underAdornment }: PageTitleSectionProps) => {
   return (
     <section className='w-full flex flex-col justify-center max-w-full px-8'>
-      <div>
-        <div className='px-2 border-b-2 flex mb-2'>
-          <h1 className='text-2xl leading-normal font-bold max-w-fit w-full truncate pb-1'>{title}</h1>
-          {aboveAdornment}
-        </div>
-        {underAdornment}
+      <div className='px-2 border-b-2 flex mb-2 justify-between'>
+        <h1 className='text-2xl leading-normal font-bold max-w-fit w-full truncate pb-1'>{title}</h1>
+        {aboveAdornment}
       </div>
+      {underAdornment}
     </section>
   );
 };

--- a/src/pages/GroupMainPage.tsx
+++ b/src/pages/GroupMainPage.tsx
@@ -9,6 +9,7 @@ import PageContainer from '@components/PageContainer';
 import Post from '@components/Post';
 import { Button } from '@material-tailwind/react';
 import LikeDislikeButton from '@components/LikeDislikeButton';
+import AddPostButton from '@components/AddPostButton';
 
 const GroupMainPage = () => {
   const navigate = useNavigate();
@@ -31,14 +32,17 @@ const GroupMainPage = () => {
       <PageContainer pageId={postList.length !== 0 ? pageId : undefined} hasRecentChangeList>
         {postList.length !== 0 ? (
           postList.map((post) => (
-            <Post
-              key={post.postId}
-              pageId={pageId}
-              pageName={pageName}
-              index={post.index}
-              postTitle={post.postTitle}
-              content={post.content}
-            />
+            <div>
+              <Post
+                key={post.postId}
+                pageId={pageId}
+                pageName={pageName}
+                index={post.index}
+                postTitle={post.postTitle}
+                content={post.content}
+              />
+              <AddPostButton />
+            </div>
           ))
         ) : (
           <article className='flex justify-between items-center p-4 bg-gray-100 rounded-lg px-4'>

--- a/src/pages/GroupMainPage.tsx
+++ b/src/pages/GroupMainPage.tsx
@@ -8,6 +8,7 @@ import PageTitleSection from '@components/PageTitleSection';
 import PageContainer from '@components/PageContainer';
 import Post from '@components/Post';
 import { Button } from '@material-tailwind/react';
+import LikeDislikeButton from '@components/LikeDislikeButton';
 
 const GroupMainPage = () => {
   const navigate = useNavigate();
@@ -26,7 +27,7 @@ const GroupMainPage = () => {
 
   return (
     <div className='mx-auto 2xl:max-w-screen-xl xl:max-w-screen-lg'>
-      <PageTitleSection title={pageName} />
+      <PageTitleSection title={pageName} aboveAdornment={<LikeDislikeButton upCount={12} downCount={7} />} />
       <PageContainer pageId={postList.length !== 0 ? pageId : undefined} hasRecentChangeList>
         {postList.length !== 0 ? (
           postList.map((post) => (


### PR DESCRIPTION
## ⭐Key Changes
> 핵심 변경 사항에 대해서 적어주세요.
![image](https://github.com/Step3-kakao-tech-campus/Team8_FE/assets/48706964/c5eccef8-2373-40f7-a002-ee85484b30f9)


1. 좋아요 싫어요 버튼 추가
2. 포스트 추가 버튼 생성
- 버튼에 마우스 올렸을 때
![image](https://github.com/Step3-kakao-tech-campus/Team8_FE/assets/48706964/1713adeb-4564-490c-bf27-5e2ebe08f1c8)

- 클릭했을 때
![image](https://github.com/Step3-kakao-tech-campus/Team8_FE/assets/48706964/8ea973e8-5a8f-4041-a8e4-5f121bcfb39e)

글에서 시선이 분산되는 걸 막기 위해 버튼 초기상태는 아주 흐린 회색과 하얀색 아이콘으로 처리했습니다.
(한번 써보면 바로 이해가능한 기능이라 평소에는 눈에 분명하게 안 들어와도 괜찮다고 생각해요.)

마우스를 올렸을 때 아이콘이 진해지면서 의미를 알 수 있게 해두었고, 클릭했을 때 나뉘어지면서 텍스트가 나타납니다.

다만 누르고나서 원래대로 돌리는 기능이 없는데... 이건 굳이 있어야하나 싶기도 합니다.
<br>

## 📌Issue
- close #70 

<br>

## 👪To Reviewers
> reviewer에게 하고 싶은 말을 적어주세요.

기능은 없고 UI만 만들었습니다.
그룹원 보는건 헤더 메뉴에 있는 편이 자연스러울 것 같아요. 초대도 거기 있어서 분리해두니까 부자연스럽네요!
그래서 헤더 메뉴에서 모달 열리도록 처리하겠습니다...!!!

<br>

## 🐾Next Move
> 다음 개발 목표를 적어주세요

일단 그룹원 리스트 보는 모달부터.