### PR TITLE
그룹원 보기 모달 구현

### DIFF
--- a/src/components/GroupMemberList.tsx
+++ b/src/components/GroupMemberList.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import { Dialog, DialogHeader, DialogBody, DialogFooter } from '@material-tailwind/react';
+import { MdClear } from 'react-icons/md';
+
+interface GroupMemberListProps {
+  isOpen: boolean;
+  handleModal: () => void;
+}
+
+const GroupMemberList = ({ isOpen, handleModal }: GroupMemberListProps) => {
+  return (
+    <Dialog open={isOpen} handler={handleModal}>
+      <button type='button' className='absolute top-4 right-4' onClick={handleModal}>
+        <MdClear className='text-3xl text-black' />
+      </button>
+      <DialogHeader className='flex-col gap-2'>
+        <p className='text-lg'>그룹원을 초대해보세요.</p>
+        <p className='text-sm text-gray-600 font-normal'>클릭하여 링크 복사</p>
+      </DialogHeader>
+      <DialogBody className='flex'>
+        <p className='px-4 py-1 bg-blue-gray-50 text-black overflow-auto'>dd</p>
+      </DialogBody>
+      <DialogFooter>hi</DialogFooter>
+    </Dialog>
+  );
+};
+
+export default GroupMemberList;

--- a/src/components/GroupMemberListModal.tsx
+++ b/src/components/GroupMemberListModal.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
-import { Dialog, DialogHeader, DialogBody, DialogFooter } from '@material-tailwind/react';
+import { Dialog, DialogHeader, DialogBody, List, ListItem } from '@material-tailwind/react';
 import { MdClear } from 'react-icons/md';
+import { groupMember } from '@dummy/group';
 
 interface GroupMemberListProps {
   isOpen: boolean;
@@ -10,18 +11,21 @@ interface GroupMemberListProps {
 
 const GroupMemberListModal = ({ isOpen, handleModal }: GroupMemberListProps) => {
   return (
-    <Dialog open={isOpen} handler={handleModal}>
+    <Dialog size='xs' open={isOpen} handler={handleModal}>
       <button type='button' className='absolute top-4 right-4' onClick={handleModal}>
         <MdClear className='text-3xl text-black' />
       </button>
-      <DialogHeader className='flex-col gap-2'>
-        <p className='text-lg'>그룹원을 초대해보세요.</p>
-        <p className='text-sm text-gray-600 font-normal'>클릭하여 링크 복사</p>
+      <DialogHeader className='flex-col gap-2 border-b'>
+        <p className='text-lg'>그룹원 보기</p>
       </DialogHeader>
-      <DialogBody className='flex'>
-        <p className='px-4 py-1 bg-blue-gray-50 text-black overflow-auto'>dd</p>
+      <DialogBody className=' h-96 overflow-y-auto'>
+        <List>
+          {/* TODO: 키 값 여기도 처리해주세요 */}
+          {groupMember.map((member) => (
+            <ListItem key={member}>{member}</ListItem>
+          ))}
+        </List>
       </DialogBody>
-      <DialogFooter>hi</DialogFooter>
     </Dialog>
   );
 };

--- a/src/components/GroupMemberListModal.tsx
+++ b/src/components/GroupMemberListModal.tsx
@@ -8,7 +8,7 @@ interface GroupMemberListProps {
   handleModal: () => void;
 }
 
-const GroupMemberList = ({ isOpen, handleModal }: GroupMemberListProps) => {
+const GroupMemberListModal = ({ isOpen, handleModal }: GroupMemberListProps) => {
   return (
     <Dialog open={isOpen} handler={handleModal}>
       <button type='button' className='absolute top-4 right-4' onClick={handleModal}>
@@ -26,4 +26,4 @@ const GroupMemberList = ({ isOpen, handleModal }: GroupMemberListProps) => {
   );
 };
 
-export default GroupMemberList;
+export default GroupMemberListModal;

--- a/src/components/HeaderMenu.tsx
+++ b/src/components/HeaderMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Menu, MenuHandler, MenuList, MenuItem, Button } from '@material-tailwind/react';
 import { MdMenu } from 'react-icons/md';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -14,7 +14,8 @@ const HeaderMenu = () => {
   const { groupName } = useParams();
   const navigate = useNavigate();
   const setIsLoggedIn = useSetRecoilState(isLoggedInState);
-  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+
+  const inviteModal = useModal();
   const groupMemberListModal = useModal();
 
   const handleLogout = () => {
@@ -27,9 +28,6 @@ const HeaderMenu = () => {
       navigate('/myPage');
     }
   };
-  const handleModalClick = () => {
-    setIsModalOpen((prev) => !prev);
-  };
 
   return (
     <>
@@ -41,12 +39,12 @@ const HeaderMenu = () => {
         </MenuHandler>
         <MenuList>
           <MenuItem onClick={handleMyPageClick}>{groupName ? '그룹 마이페이지' : '마이페이지'}</MenuItem>
-          {groupName && <MenuItem onClick={handleModalClick}>그룹원 초대</MenuItem>}
+          {groupName && <MenuItem onClick={inviteModal.handleModal}>그룹원 초대</MenuItem>}
           {groupName && <MenuItem onClick={groupMemberListModal.handleModal}>그룹원 목록</MenuItem>}
           <MenuItem onClick={handleLogout}>로그아웃</MenuItem>
         </MenuList>
       </Menu>
-      <InviteModal code={inviteCodeDummyData} isOpen={isModalOpen} onModalClick={handleModalClick} />
+      <InviteModal code={inviteCodeDummyData} isOpen={inviteModal.isOpen} onModalClick={inviteModal.handleModal} />
       <GroupMemberList isOpen={groupMemberListModal.isOpen} handleModal={groupMemberListModal.handleModal} />
     </>
   );

--- a/src/components/HeaderMenu.tsx
+++ b/src/components/HeaderMenu.tsx
@@ -5,13 +5,17 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
 import isLoggedInState from '@recoil/login/atoms';
 import { inviteCodeDummyData } from '@dummy/group';
+import useModal from '@hooks/useModal';
+
 import InviteModal from './InviteModal';
+import GroupMemberList from './GroupMemberList';
 
 const HeaderMenu = () => {
   const { groupName } = useParams();
   const navigate = useNavigate();
   const setIsLoggedIn = useSetRecoilState(isLoggedInState);
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const groupMemberListModal = useModal();
 
   const handleLogout = () => {
     setIsLoggedIn(false);
@@ -38,10 +42,12 @@ const HeaderMenu = () => {
         <MenuList>
           <MenuItem onClick={handleMyPageClick}>{groupName ? '그룹 마이페이지' : '마이페이지'}</MenuItem>
           {groupName && <MenuItem onClick={handleModalClick}>그룹원 초대</MenuItem>}
+          {groupName && <MenuItem onClick={groupMemberListModal.handleModal}>그룹원 목록</MenuItem>}
           <MenuItem onClick={handleLogout}>로그아웃</MenuItem>
         </MenuList>
       </Menu>
       <InviteModal code={inviteCodeDummyData} isOpen={isModalOpen} onModalClick={handleModalClick} />
+      <GroupMemberList isOpen={groupMemberListModal.isOpen} handleModal={groupMemberListModal.handleModal} />
     </>
   );
 };

--- a/src/components/HeaderMenu.tsx
+++ b/src/components/HeaderMenu.tsx
@@ -8,7 +8,7 @@ import { inviteCodeDummyData } from '@dummy/group';
 import useModal from '@hooks/useModal';
 
 import InviteModal from './InviteModal';
-import GroupMemberList from './GroupMemberList';
+import GroupMemberListModal from './GroupMemberListModal';
 
 const HeaderMenu = () => {
   const { groupName } = useParams();
@@ -45,7 +45,7 @@ const HeaderMenu = () => {
         </MenuList>
       </Menu>
       <InviteModal code={inviteCodeDummyData} isOpen={inviteModal.isOpen} onModalClick={inviteModal.handleModal} />
-      <GroupMemberList isOpen={groupMemberListModal.isOpen} handleModal={groupMemberListModal.handleModal} />
+      <GroupMemberListModal isOpen={groupMemberListModal.isOpen} handleModal={groupMemberListModal.handleModal} />
     </>
   );
 };

--- a/src/components/HeaderMenu.tsx
+++ b/src/components/HeaderMenu.tsx
@@ -36,7 +36,7 @@ const HeaderMenu = () => {
           </Button>
         </MenuHandler>
         <MenuList>
-          <MenuItem onClick={handleMyPageClick}>마이페이지</MenuItem>
+          <MenuItem onClick={handleMyPageClick}>{groupName ? '그룹 마이페이지' : '마이페이지'}</MenuItem>
           {groupName && <MenuItem onClick={handleModalClick}>그룹원 초대</MenuItem>}
           <MenuItem onClick={handleLogout}>로그아웃</MenuItem>
         </MenuList>

--- a/src/dummy/group.ts
+++ b/src/dummy/group.ts
@@ -172,3 +172,21 @@ export const groupMyPageDummyData: GroupMypage = {
     },
   ],
 };
+
+export const groupMember: string[] = [
+  'apple',
+  'banana',
+  'cherry',
+  'date',
+  'elderberry',
+  'fig',
+  'grape',
+  'honeydew',
+  'indigo',
+  'jicama',
+  'kiwi',
+  'lemon',
+  'mango',
+  'nectarine',
+  'orange',
+];

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,0 +1,13 @@
+import { useState } from 'react';
+
+const useModal = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleModal = () => {
+    setIsOpen((prev) => !prev);
+  };
+
+  return { isOpen, handleModal };
+};
+
+export default useModal;

--- a/src/pages/GroupMyPage.tsx
+++ b/src/pages/GroupMyPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState, ChangeEvent } from 'react';
 import { Button, Input } from '@material-tailwind/react';
 import { useNavigate, useParams } from 'react-router-dom';
+import useModal from '@hooks/useModal';
 import ContributeList from '@components/ContributeList';
 import QuitModal from '@components/QuitModal';
 import { groupMyPageDummyData } from '@dummy/group';
@@ -10,14 +11,12 @@ const GroupMyPage = () => {
   const { groupName } = useParams();
   const [nickName, setNickName] = useState(groupMyPageDummyData.groupNickName);
   const [isNickNameChanging, setIsNickNameChanging] = useState<boolean>(false);
-  const [isQuitModalOpen, setIsQuitModalOpen] = useState<boolean>(false);
+  const quitModal = useModal();
 
   const handleNickName = (e: ChangeEvent<HTMLInputElement>) => {
     setNickName(e.target.value);
   };
-  const handleQuitModal = () => {
-    setIsQuitModalOpen((prev) => !prev);
-  };
+
   const handleNickNameChage = () => {
     setIsNickNameChanging((prev) => !prev);
   };
@@ -99,11 +98,11 @@ const GroupMyPage = () => {
           variant='text'
           ripple={false}
           className='p-1 rounded-sm whitespace-nowrap text-red-600 hover:bg-transparent active:bg-transparent hover:underline decoration-black'
-          onClick={handleQuitModal}
+          onClick={quitModal.handleModal}
         >
           그룹 탈퇴하기
         </Button>
-        <QuitModal group={groupName} isOpen={isQuitModalOpen} onClick={handleQuitModal} />
+        <QuitModal group={groupName} isOpen={quitModal.isOpen} onClick={quitModal.handleModal} />
       </div>
     </main>
   );

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,14 +1,14 @@
 import React, { ChangeEvent, useState } from 'react';
+import useModal from '@hooks/useModal';
 import { Button, Input } from '@material-tailwind/react';
 import GroupList from '@components/GroupList';
 import { unOfficialGroupDummyData, groupMyPageDummyData } from '@dummy/group';
 import PasswordChangeModal from '@components/PasswordChangeModal';
 
 const MyPage = () => {
-  const [isOpen, setIsOpen] = useState<boolean>(false);
-  const handleOpen = () => setIsOpen(!isOpen);
   const [nickName, setNickName] = useState(groupMyPageDummyData.groupNickName);
   const [isNickNameChanging, setIsNickNameChanging] = useState<boolean>(false);
+  const passwordChangeModal = useModal();
 
   const handleNickName = (e: ChangeEvent<HTMLInputElement>) => {
     setNickName(e.target.value);
@@ -78,13 +78,13 @@ const MyPage = () => {
             variant='outlined'
             color='gray'
             className='rounded-sm h-9 w-20 p-1 whitespace-nowrap'
-            onClick={handleOpen}
+            onClick={passwordChangeModal.handleModal}
           >
             바로가기
           </Button>
           <p className='text-xs text-gray-700 ml-4'>카카오톡 간편 회원은 지원하지 않는 기능입니다.</p>
         </div>
-        <PasswordChangeModal isOpen={isOpen} handleOpen={handleOpen} />
+        <PasswordChangeModal isOpen={passwordChangeModal.isOpen} handleOpen={passwordChangeModal.handleModal} />
         <div className='flex items-baseline mt-10 mb-10'>
           <span className='font-extrabold w-40'>내 그룹 보기</span>
           <p className='text-xs text-gray-700'>프로필을 누르면 그룹으로 이동합니다.</p>

--- a/src/pages/PostEditPage.tsx
+++ b/src/pages/PostEditPage.tsx
@@ -1,4 +1,5 @@
 import React, { ChangeEvent, useState } from 'react';
+import useModal from '@hooks/useModal';
 import PageContainer from '@components/PageContainer';
 import PageTitleSection from '@components/PageTitleSection';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -11,7 +12,7 @@ const PostEditPage = () => {
   const navigate = useNavigate();
   const [title, setTitle] = useState<string>(postTitle);
   const [content, setContent] = useState<string>(postContent);
-  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState<boolean>(false);
+  const deleteModal = useModal();
 
   const handleTitleChange = (e: ChangeEvent<HTMLInputElement>) => {
     setTitle(e.target.value);
@@ -21,9 +22,6 @@ const PostEditPage = () => {
   };
   const handleSaveClick = () => {
     // api 연결 후 작성
-  };
-  const handleDeleteModal = () => {
-    setIsDeleteModalOpen((prev) => !prev);
   };
 
   return (
@@ -50,7 +48,7 @@ const PostEditPage = () => {
               variant='text'
               ripple={false}
               className='py-1 px-3 text-red-600 hover:bg-transparent hover:underline active:bg-transparent decoration-black'
-              onClick={handleDeleteModal}
+              onClick={deleteModal.handleModal}
             >
               삭제하기
             </Button>
@@ -68,7 +66,7 @@ const PostEditPage = () => {
               </Button>
             </div>
           </div>
-          <PostDeleteModal title={title} isOpen={isDeleteModalOpen} onClickModal={handleDeleteModal} />
+          <PostDeleteModal title={title} isOpen={deleteModal.isOpen} onClickModal={deleteModal.handleModal} />
         </article>
       </PageContainer>
     </div>

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -7,7 +7,8 @@
       "@pages/*": ["src/pages/*"],
       "@recoil/*": ["src/recoil/*"],
       "@test/*": ["src/test/*"],
-      "@dummy/*": ["src/dummy/*"]
+      "@dummy/*": ["src/dummy/*"],
+      "@hooks/*": ["src/hooks/*"]
     }
   }
 }

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -8,7 +8,7 @@
       "@recoil/*": ["src/recoil/*"],
       "@test/*": ["src/test/*"],
       "@dummy/*": ["src/dummy/*"],
-      "@hooks/*": ["src/hooks/*"]
+      "@hooks/*": ["src/hooks/*"],
       "@constants/*": ["src/constants/*"],
       "@apis/*": ["src/apis/*"]
     }


### PR DESCRIPTION
## ⭐Key Changes
> 핵심 변경 사항에 대해서 적어주세요.
1. 헤더 메뉴에 그룹원 보기 추가
2. 그룹원 보기 모달 구현
3. 커스텀 훅 적용
```
import { useState } from 'react';

const useModal = () => {
  const [isOpen, setIsOpen] = useState(false);

  const handleModal = () => {
    setIsOpen((prev) => !prev);
  };

  return { isOpen, handleModal };
};

export default useModal;
```

모달 쓸 때마다 하나하나 isOpen, setIsOpen 만들고 상태 바꾸는 함수 구현하도록 해왔었는데, 코드 재사용을 위해 훅을 만들었습니다.
아래와 같이 사용하시면 됩니다.
```
// 선언
const modal = useModal();

// 렌더링
<Modal isOpen={modal.isOpen} onClick={modal.handleModal} />
```

참고로 기존에 사용하던 부분 모두 해당 훅으로 바꿔놨습니다.

<br>

## 📌Issue
- Close #93 

<br>

## 👪To Reviewers
> reviewer에게 하고 싶은 말을 적어주세요.

모달 디자인 그냥 별 거 없이 심플하게 했습니다. 모달 폭이 가로로 좀 큰가 싶기도 한데... 혹여 나중에 멤버에 추가 정보 들어갈 수도 있어서 그냥 이름만 보여주는걸로 픽스되면 디자인 수정할 때 바꾸도록 하겠습니다!
(안 크고 적당하다 싶으면 놔두고요)

<br>

## 🐾Next Move
> 다음 개발 목표를 적어주세요
