### PR TITLE
히스토리 페이지

### DIFF
--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -30,7 +30,8 @@ const Pagination = ({ active, setActive, lastIndex }: PaginationProps) => {
         <MdArrowBack size={15} />
       </IconButton>
       <Typography color='gray' className='font-normal'>
-        Page <strong className='text-gray-900'>{active}</strong> of <strong className='text-gray-900'>10</strong>
+        Page <strong className='text-gray-900'>{active}</strong> of{' '}
+        <strong className='text-gray-900'>{lastIndex}</strong>
       </Typography>
       <IconButton size='sm' variant='text' onClick={handleNext} disabled={active === lastIndex}>
         <MdArrowForward size={15} />

--- a/src/components/Post.tsx
+++ b/src/components/Post.tsx
@@ -69,7 +69,10 @@ const Post = ({ pageId, pageName, index, postTitle, content }: PostProps) => {
                   편집
                 </Typography>
               </MenuItem>
-              <MenuItem className='flex items-center gap-2 py-1'>
+              <MenuItem
+                className='flex items-center gap-2 py-1'
+                onClick={() => navigate(`${pageName}/${postTitle}/history`)}
+              >
                 <MdOutlineHistory className='text-2xl' />
                 <Typography variant='small' className='font-semibold'>
                   히스토리

--- a/src/components/PostHistoryAccordion.tsx
+++ b/src/components/PostHistoryAccordion.tsx
@@ -25,7 +25,7 @@ const PostHistoryAccordion = ({ historyList }: PostHistoryAccordionProps) => {
   };
 
   const handleUndoButtonClick = () => {
-    alert('해당 내용으로 되돌리기');
+    // TODO: 되돌리기 모달 추후 구현
   };
 
   useEffect(() => {

--- a/src/components/PostHistoryAccordion.tsx
+++ b/src/components/PostHistoryAccordion.tsx
@@ -1,8 +1,22 @@
-import React, { useState } from 'react';
-import { Accordion, AccordionHeader, AccordionBody } from '@material-tailwind/react';
+import React, { useEffect, useState } from 'react';
+import { Accordion, AccordionHeader, AccordionBody, Button, Chip } from '@material-tailwind/react';
+import { MdExpandMore, MdExpandLess } from 'react-icons/md';
 
-const PostHistoryAccordion = () => {
-  const [openAccordion, setOpenAccordion] = useState(new Array(20).fill(false));
+interface History {
+  memberId: number;
+  nickName: string;
+  historyId: number;
+  title: string;
+  content: string;
+  createdAt: string;
+}
+
+interface PostHistoryAccordionProps {
+  historyList: History[];
+}
+
+const PostHistoryAccordion = ({ historyList }: PostHistoryAccordionProps) => {
+  const [openAccordion, setOpenAccordion] = useState(new Array(5).fill(false));
 
   const handleOpenAccordion = (index: number) => {
     const newAccordionState = [...openAccordion];
@@ -10,12 +24,54 @@ const PostHistoryAccordion = () => {
     setOpenAccordion(newAccordionState);
   };
 
+  const handleUndoButtonClick = () => {
+    alert('해당 내용으로 되돌리기');
+  };
+
+  useEffect(() => {
+    setOpenAccordion((prev) => {
+      const newAccordionState = [...prev];
+      newAccordionState[0] = true;
+      return newAccordionState;
+    });
+  }, []);
+
   return (
     <>
-      {openAccordion.map((isOpen, index) => (
-        <Accordion key={index} open={isOpen}>
-          <AccordionHeader onClick={() => handleOpenAccordion(index)}>{`Accordion ${index + 1}`}</AccordionHeader>
-          <AccordionBody>내용내용</AccordionBody>
+      {historyList.map((history, index) => (
+        // TODO: 키 값 처리
+        <Accordion
+          key={history.historyId}
+          open={openAccordion[index]}
+          icon={openAccordion[index] ? <MdExpandLess size={20} /> : <MdExpandMore size={20} />}
+        >
+          <AccordionHeader
+            onClick={() => handleOpenAccordion(index)}
+            className='text-sm font-normal flex justify-between pb-2'
+          >
+            <div className='flex gap-2 items-center'>
+              {`${history.createdAt.replace('T', ' ')} by ${history.nickName}`}
+              {index === 0 && (
+                <Chip variant='ghost' size='sm' color='deep-orange' value='현재' className=' rounded-full' />
+              )}
+            </div>
+          </AccordionHeader>
+          <AccordionBody className='whitespace-prewrap text-xs font-normal text-gray-600'>
+            {history.content}
+            {index !== 0 && (
+              <div className='flex justify-end'>
+                <Button
+                  ripple={false}
+                  variant='text'
+                  size='sm'
+                  className=' text-red-300 px-2 py-1 text-right'
+                  onClick={handleUndoButtonClick}
+                >
+                  [해당 내용으로 되돌리기]
+                </Button>
+              </div>
+            )}
+          </AccordionBody>
         </Accordion>
       ))}
     </>

--- a/src/components/PostHistoryAccordion.tsx
+++ b/src/components/PostHistoryAccordion.tsx
@@ -1,0 +1,25 @@
+import React, { useState } from 'react';
+import { Accordion, AccordionHeader, AccordionBody } from '@material-tailwind/react';
+
+const PostHistoryAccordion = () => {
+  const [openAccordion, setOpenAccordion] = useState(new Array(20).fill(false));
+
+  const handleOpenAccordion = (index: number) => {
+    const newAccordionState = [...openAccordion];
+    newAccordionState[index] = !newAccordionState[index];
+    setOpenAccordion(newAccordionState);
+  };
+
+  return (
+    <>
+      {openAccordion.map((isOpen, index) => (
+        <Accordion key={index} open={isOpen}>
+          <AccordionHeader onClick={() => handleOpenAccordion(index)}>{`Accordion ${index + 1}`}</AccordionHeader>
+          <AccordionBody>내용내용</AccordionBody>
+        </Accordion>
+      ))}
+    </>
+  );
+};
+
+export default PostHistoryAccordion;

--- a/src/dummy/page.ts
+++ b/src/dummy/page.ts
@@ -134,3 +134,50 @@ export const comments: Comment[] = [
     createdAt: '2023.10.14',
   },
 ];
+
+interface History {
+  memberId: number;
+  nickName: string;
+  historyId: number;
+  title: string;
+  content: string;
+  createdAt: string;
+}
+
+interface PostHistory {
+  postId: number;
+  currentTitle: string;
+  historyList: History[];
+}
+
+export const postHistoryDummyData: PostHistory = {
+  postId: 1,
+  currentTitle: '개요',
+  historyList: [
+    {
+      memberId: 1,
+      nickName: '이경우',
+      historyId: 1,
+      title: '개요',
+      content:
+        '이 작품의 주역인 선택받은 아이들은 각 캐릭터마다 테마를 갖고 있는데, 저마다 가진 8개의 문장이 갖는 가치(좌측부터 용기, 우정, 사랑, 지식, 희망, 순수, 성실, 빛)가 바로 그것이다. 실제로 캐릭터들은 그 진리에 맞는 성격을 지니고 있으나, 동시에 이 가치들은 약점이자 콤플렉스로서 기능하기도 한다. 가령 태일은 용기가 뛰어나지만 때론 만용을 부리며 무모한 일에 타인을 끌어들이고, 매튜는 브라더 콤플렉스로 우정을 의심한다. 또 소라는 어머니의 사랑을 강박으로 받아들이기도 했고, 한솔은 지식만으로 사물을 판단해 타인에 대한 배려가 부족했다. 이미나는 순수가 도를 넘어 응석에 가까운 수준이었고 정석도 성실함이 지나친 나머지 스스로도 고지식으로 받아들일 만큼 융통성이 부족했다. 각각의 캐릭터들은 자신의 장점이자 결핍이기도 한 이들 가치를 극복하는 과정을 겪으며 그 문장의 힘을 자신의 것으로 체화해나가며, 그 과정은 훌륭한 전개 덕에 어색함 없이 매우 자연스럽게 다가온다.',
+      createdAt: '2023-10-12T14:30:34',
+    },
+    {
+      memberId: 2,
+      nickName: '김경우',
+      historyId: 2,
+      title: '개요',
+      content: '내용... ㅇㅇㅇㅇㅇㅇ',
+      createdAt: '2023-10-11T14:30:34',
+    },
+    {
+      memberId: 3,
+      nickName: '박경우',
+      historyId: 3,
+      title: '개요',
+      content: '내용...',
+      createdAt: '2023-10-09T14:30:34',
+    },
+  ],
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,6 +16,7 @@ import GroupSearchResultPage from '@pages/GroupSearchResultPage';
 import GroupCreatePage from '@pages/GroupCreatePage';
 import ReportPage from '@pages/ReportPage';
 import PostEditPage from '@pages/PostEditPage';
+import PostHistoryPage from '@pages/PostHistoryPage';
 
 import MainLayout from '@components/MainLayout';
 import PageLayout from '@components/PageLayout';
@@ -68,6 +69,10 @@ const router = createBrowserRouter([
           {
             path: '/:groupName/:page/:postId/report',
             element: <ReportPage />,
+          },
+          {
+            path: '/:groupName/:page/:postId/history',
+            element: <PostHistoryPage />,
           },
         ],
       },

--- a/src/pages/PostHistoryPage.tsx
+++ b/src/pages/PostHistoryPage.tsx
@@ -1,7 +1,23 @@
 import React from 'react';
 
+import PostHistoryAccordion from '@components/PostHistoryAccordion';
+import Pagination from '@components/Pagination';
+import { postHistoryDummyData } from '@dummy/page';
+
 const PostHistoryPage = () => {
-  return <div>PostHistoryPage</div>;
+  const [active, setActive] = React.useState<number>(1);
+
+  return (
+    <section className='max-w-3xl sm:w-[90vw] mx-auto'>
+      <h1 className='inline pb-4 pr-40 mb-20 text-xl font-extrabold border border-x-0 border-b-1 border-t-0 border-black'>
+        &quot;{postHistoryDummyData.currentTitle}&quot; 글의 히스토리
+      </h1>
+      <div className='mt-16 mb-10'>
+        <PostHistoryAccordion historyList={postHistoryDummyData.historyList} />
+      </div>
+      <Pagination active={active} setActive={setActive} lastIndex={5} />
+    </section>
+  );
 };
 
 export default PostHistoryPage;

--- a/src/pages/PostHistoryPage.tsx
+++ b/src/pages/PostHistoryPage.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const PostHistoryPage = () => {
+  return <div>PostHistoryPage</div>;
+};
+
+export default PostHistoryPage;


### PR DESCRIPTION
## ⭐Key Changes
> 핵심 변경 사항에 대해서 적어주세요.
1. 히스토리 페이지 버튼 및 라우터 연결
2. 페이지 UI 구현
![image](https://github.com/Step3-kakao-tech-campus/Team8_FE/assets/48706964/f1b561e7-9aa6-4ea1-ab9c-4f049ec3ad8f)

가장 위의 글은 현재 글과 동일합니다(API 기준).
따라서 현재 글을 명시하는 Chip을 붙였고 해당 페이지에 접근 시 자동으로 열리게 처리하였습니다.

<br>

## 📌Issue
- Close #95 

<br>

## 👪To Reviewers
- 되돌리기 버튼 누르면 안내 모달 나오게 하려고 했는데, 모달 훅으로 바꿔둔 부분 머지된 후에 처리하는 게 나을 것 같아 TODO로 남겨두었습니다.

- 원래 와이어프레임은 페이지 단위로 히스토리를 볼 수 있게 하여 페이지 이름이 크게 나오면서 해당 컴포넌트가 페이지 레이아웃 안에 존재했는데, 실제 구현은 글마다 히스토리가 있어 아예 다른 페이지로 빼냈습니다.

- 기여목록은 한 아코디언을 누르면 다른 것이 닫히는데, 히스토리 페이지는 여러 글을 비교하며 볼 필요성이 있을 것 같아서 각 아코디언이 개별로 동작하게 구현했습니다.

- 제 모니터 기준 125%로 작업했는데 100%로 하면 많이 작더군요. 다른 모니터에서 제대로 보이는지 확인 부탁드립니다. 😢
<br>

## 🐾Next Move
> 다음 개발 목표를 적어주세요
