### PR TITLE
목차 이동

### DIFF
--- a/src/components/IndexList.tsx
+++ b/src/components/IndexList.tsx
@@ -8,6 +8,14 @@ interface IndexListProps {
 const IndexList = ({ pageId }: IndexListProps) => {
   const indexList = getIndexList(pageId);
 
+  const scrollToPost = (postId: string) => {
+    console.log(postId);
+    const postElement = document.getElementById(postId);
+    if (postElement) {
+      window.scrollTo({ top: postElement.offsetTop - 60, behavior: 'smooth' });
+    }
+  };
+
   return (
     <div className='w-full'>
       <h2 className='font-bold px-1 py-2 text-sm'>목차</h2>
@@ -15,7 +23,9 @@ const IndexList = ({ pageId }: IndexListProps) => {
         {indexList.map((post) => (
           <li key={post.index} className='my-2 leading-tight whitespace-pre'>
             {post.index.split('.').length > 2 && '  '}
-            <span className='text-indigo-500'>{post.index}</span> {post.postTitle}
+            <button type='button' onClick={() => scrollToPost(`${pageId}-${post.index}`)}>
+              <span className='text-indigo-500'>{post.index}</span> {post.postTitle}
+            </button>
           </li>
         ))}
       </ul>

--- a/src/components/Post.tsx
+++ b/src/components/Post.tsx
@@ -26,6 +26,7 @@ const Post = ({ pageId, pageName, index, postTitle, content }: PostProps) => {
 
   const navigate = useNavigate();
   const [isCommentOpen, setIsCommentOpen] = useState<boolean>(false);
+  const postId = `${pageId}-${index}`;
 
   const handleCommentClick = () => {
     setIsCommentOpen((prev) => !prev);
@@ -35,7 +36,7 @@ const Post = ({ pageId, pageName, index, postTitle, content }: PostProps) => {
   };
 
   return (
-    <article>
+    <article id={postId}>
       <div className='flex justify-between border-b-2'>
         <h2 className='text-xl leading-relaxed font-semibold'>
           <span className='text-indigo-500'>{index}</span> {postTitle}

--- a/src/dummy/page.ts
+++ b/src/dummy/page.ts
@@ -58,13 +58,15 @@ export const getPageInfo = (groupName: string): PageInfo => ({
       postId: 2,
       index: '2.',
       postTitle: '역사',
-      content: '내용...',
+      content:
+        '<h3>여름방학을 맞아 캠프장을 찾아온 선택받은 아이들.</h3><p>&nbsp;</p><p>캠프장에서 아이들은 각자 디지바이스(디지몬 어드벤처)를 줍게 되고 갑자기 [[디지털 월드|알 수 없는 이상한 공간]]속으로 빨려 들어가게 된다. 정신을 차린 아이들 앞에는 아이들을 기다리고 있었다던 [[디지몬|괴생물체]]가 있었고 자기들을 파트너 [[디지몬]]이라 소개한다.</p><figure class="table"><table><tbody><tr><th>wefewfe</th><td>wef</td><td>weg</td><td>asdg</td></tr><tr><th>weg</th><td>fwefg</td><td colspan="2" rowspan="2"><p>weg</p><p>ewf</p><p>wegwe</p><p>efew</p></td></tr><tr><th>fwef</th><td>fwewef</td></tr></tbody></table></figure><p>&nbsp;</p><p>정신을 차릴새도 없이 악의를 품은 디지몬들이 습격해 오기 시작하고 아이들은 살아남기 위해, 다시 현실세계로 돌아가기 위해 [[모험]]을 시작한다. 아이들이 위험에 처할 때마다 [[디지바이스(디지몬 어드벤처)|디지바이스]]가 빛나며 파트너 디지몬이 [[성숙기]]로 [[진화(디지몬 시리즈)|진화]]해 위기를 극복하며, 점차 이 곳은 현실세계와는 [[디지털 월드|뭔가 다른 곳의 세상]]의 파일섬이란 것을 알게 된다.</p>',
     },
     {
       postId: 4,
       index: '2.1.',
       postTitle: '컴공의 역사',
-      content: '내용...',
+      content:
+        '<h3>여름방학을 맞아 캠프장을 찾아온 선택받은 아이들.</h3><p>&nbsp;</p><p>캠프장에서 아이들은 각자 디지바이스(디지몬 어드벤처)를 줍게 되고 갑자기 [[디지털 월드|알 수 없는 이상한 공간]]속으로 빨려 들어가게 된다. 정신을 차린 아이들 앞에는 아이들을 기다리고 있었다던 [[디지몬|괴생물체]]가 있었고 자기들을 파트너 [[디지몬]]이라 소개한다.</p><figure class="table"><table><tbody><tr><th>wefewfe</th><td>wef</td><td>weg</td><td>asdg</td></tr><tr><th>weg</th><td>fwefg</td><td colspan="2" rowspan="2"><p>weg</p><p>ewf</p><p>wegwe</p><p>efew</p></td></tr><tr><th>fwef</th><td>fwewef</td></tr></tbody></table></figure><p>&nbsp;</p><p>정신을 차릴새도 없이 악의를 품은 디지몬들이 습격해 오기 시작하고 아이들은 살아남기 위해, 다시 현실세계로 돌아가기 위해 [[모험]]을 시작한다. 아이들이 위험에 처할 때마다 [[디지바이스(디지몬 어드벤처)|디지바이스]]가 빛나며 파트너 디지몬이 [[성숙기]]로 [[진화(디지몬 시리즈)|진화]]해 위기를 극복하며, 점차 이 곳은 현실세계와는 [[디지털 월드|뭔가 다른 곳의 세상]]의 파일섬이란 것을 알게 된다.</p>',
     },
   ],
   goodCount: 7326,


### PR DESCRIPTION
## ⭐Key Changes
> 핵심 변경 사항에 대해서 적어주세요.
1. 목차를 누르면 이동합니다!!!
2. offset을 줘서 헤더 높이만큼 빼고 내려가도록 설정

![image](https://github.com/Step3-kakao-tech-campus/Team8_FE/assets/48706964/af86d0f8-0b00-4e60-9494-71426b60055f)

누르면 이정도의 여유를 두고 스크롤됩니다.

<br>

## 📌Issue
- Close #97 

<br>

## 👪To Reviewers
> reviewer에게 하고 싶은 말을 적어주세요.

몰아서 올리게 되어 죄송합니다 몸이 이제 좀 괜찮아져서 벼락치기를 해버렸거든요...
간단한 기능이라 큰 이슈 없을 것 같습니다.

+ 화면 크기가 작을 땐 목차가 위에 고정되어있어서 이동이 불편한데요, 이건 나중에 목차를 서랍 형식으로 꺼내게 바꾸거나 아니면 모든 페이지에 최상단으로 이동하는 버튼을 하나 만들어서 보완하면 좋을 것 같습니다.

<br>
