### PR TITLE
Feature/회원가입 페이지 기능 구현

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
     'react/jsx-filename-extension': ['warn', { extensions: ['.tsx'] }], // tsx파일에도 jsx 구문 사용 가능하도록 허용
     'import/extensions': 'off',
     'react/require-default-props': 'off',
+    'react/jsx-props-no-spreading': 'off',
     'import/no-extraneous-dependencies': ['error', { devDependencies: true }],
     'react/function-component-definition': [
       'error',

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.env*

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "cross-env": "^7.0.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-hook-form": "^7.47.0",
         "react-icons": "^4.11.0",
         "react-router-dom": "^6.16.0",
         "react-scripts": "5.0.1",
@@ -17264,6 +17265,21 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
+    "node_modules/react-hook-form": {
+      "version": "7.47.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.47.0.tgz",
+      "integrity": "sha512-F/TroLjTICipmHeFlMrLtNLceO2xr1jU3CyiNla5zdwsGUGu2UOxxR4UyJgLlhMwLW/Wzp4cpJ7CPfgJIeKdSg==",
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18"
+      }
+    },
     "node_modules/react-icons": {
       "version": "4.11.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.11.0.tgz",
@@ -33216,6 +33232,12 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+    },
+    "react-hook-form": {
+      "version": "7.47.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.47.0.tgz",
+      "integrity": "sha512-F/TroLjTICipmHeFlMrLtNLceO2xr1jU3CyiNla5zdwsGUGu2UOxxR4UyJgLlhMwLW/Wzp4cpJ7CPfgJIeKdSg==",
+      "requires": {}
     },
     "react-icons": {
       "version": "4.11.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "cross-env": "^7.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hook-form": "^7.47.0",
     "react-icons": "^4.11.0",
     "react-router-dom": "^6.16.0",
     "react-scripts": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -71,5 +71,10 @@
   },
   "overrides": {
     "typescript": "^5.2.2"
+  },
+  "jest": {
+    "transformIgnorePatterns": [
+      "/node_modules/(?!(axios)/)"
+    ]
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,11 @@
 import React from 'react';
 import { Outlet } from 'react-router-dom';
 import { RecoilRoot } from 'recoil';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from '@material-tailwind/react';
+import { queryClient } from '@apis/queryClient';
 import Header from '@components/Header';
 import Footer from '@components/Footer';
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      retry: 0,
-    },
-  },
-});
 
 const App = () => {
   return (

--- a/src/apis/authApi.ts
+++ b/src/apis/authApi.ts
@@ -1,0 +1,11 @@
+import { instance } from './axios';
+
+const ENDPOINT = '/auth';
+
+// eslint-disable-next-line import/prefer-default-export
+export const signUpFn = ({ email, password, name }: { email: string; password: string; name: string }) =>
+  instance.post(`${ENDPOINT}/signup`, {
+    email,
+    password,
+    nickName: name,
+  });

--- a/src/apis/axios.ts
+++ b/src/apis/axios.ts
@@ -1,0 +1,6 @@
+/* eslint-disable import/prefer-default-export */
+import axios from 'axios';
+
+export const instance = axios.create({
+  baseURL: process.env.REACT_APP_API_URL,
+});

--- a/src/apis/queryClient.ts
+++ b/src/apis/queryClient.ts
@@ -1,0 +1,10 @@
+/* eslint-disable import/prefer-default-export */
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 0,
+    },
+  },
+});

--- a/src/constants/errorMsg.ts
+++ b/src/constants/errorMsg.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export const REQUIRE_ERROR_MSG = '필수값입니다.';

--- a/src/constants/errorMsg.ts
+++ b/src/constants/errorMsg.ts
@@ -1,4 +1,5 @@
 export const REQUIRE_ERROR_MSG = '필수값입니다.';
 export const EMAIL_ERROR_MSG = '이메일 형식이 맞지 않습니다.';
 export const PASSWORD_ERROR_MSG = '8~20자 영문과 숫자를 사용하세요.';
+export const PASSWORD_CONFIRM_ERROR_MSG = '비밀번호가 일치하지 않습니다.';
 export const NAME_ERROR_MSG = '1~10자 한글, 영어만 가능합니다.';

--- a/src/constants/errorMsg.ts
+++ b/src/constants/errorMsg.ts
@@ -1,2 +1,4 @@
-// eslint-disable-next-line import/prefer-default-export
 export const REQUIRE_ERROR_MSG = '필수값입니다.';
+export const EMAIL_ERROR_MSG = '이메일 형식이 맞지 않습니다.';
+export const PASSWORD_ERROR_MSG = '8~20자 영문과 숫자를 사용하세요.';
+export const NAME_ERROR_MSG = '1~10자 한글, 영어만 가능합니다.';

--- a/src/constants/validationPatterns.ts
+++ b/src/constants/validationPatterns.ts
@@ -1,0 +1,3 @@
+export const EMAIL_PATTERN = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/;
+export const PASSWORD_PATTERN = /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,20}$/;
+export const NAME_PATTERN = /^[가-힣a-zA-Z]{1,10}$/;

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -12,42 +12,56 @@ interface SignUpInputs {
 }
 
 const SignUpPage = () => {
-  const { register } = useForm<SignUpInputs>();
+  const {
+    register,
+    formState: { errors },
+  } = useForm<SignUpInputs>({ mode: 'onChange' });
 
   return (
     <div className='flex min-h-full flex-col justify-center px-8'>
       <div className='mx-auto space-y-4 w-full shadow max-w-[450px] px-16 pt-9 pb-16'>
         <TextLogo className='w-36 m-auto mb-8' data-testid='textLogo' />
         <form className='space-y-12'>
-          <Input
-            label='이메일'
-            type='email'
-            crossOrigin=''
-            data-testid='email'
-            {...register('email', {
-              required: REQUIRE_ERROR_MSG,
-              pattern: { value: EMAIL_PATTERN, message: '이메일 주소를 다시 확인해주세요.' },
-            })}
-          />
-          <Input
-            label='비밀번호'
-            type='password'
-            crossOrigin=''
-            data-testid='password'
-            {...register('password', {
-              required: REQUIRE_ERROR_MSG,
-              pattern: { value: PASSWORD_PATTERN, message: '8~20자 영문과 숫자를 사용하세요.' },
-            })}
-          />
-          <Input
-            label='이름'
-            crossOrigin=''
-            data-testid='name'
-            {...register('name', {
-              required: REQUIRE_ERROR_MSG,
-              pattern: { value: NAME_PATTERN, message: '1~10자 한글, 영어만 가능합니다.' },
-            })}
-          />
+          <div>
+            <Input
+              label='이메일'
+              type='email'
+              crossOrigin=''
+              data-testid='email'
+              {...register('email', {
+                required: REQUIRE_ERROR_MSG,
+                pattern: { value: EMAIL_PATTERN, message: '이메일 형식이 맞지 않습니다.' },
+              })}
+            />
+            {errors.email && <p className='text-xs mt-1 mx-1 flex items-center text-error'>{errors.email.message}</p>}
+          </div>
+          <div>
+            <Input
+              label='비밀번호'
+              type='password'
+              crossOrigin=''
+              data-testid='password'
+              {...register('password', {
+                required: REQUIRE_ERROR_MSG,
+                pattern: { value: PASSWORD_PATTERN, message: '8~20자 영문과 숫자를 사용하세요.' },
+              })}
+            />
+            {errors.password && (
+              <p className='text-xs mt-1 mx-1 flex items-center text-error'>{errors.password.message}</p>
+            )}
+          </div>
+          <div>
+            <Input
+              label='이름'
+              crossOrigin=''
+              data-testid='name'
+              {...register('name', {
+                required: REQUIRE_ERROR_MSG,
+                pattern: { value: NAME_PATTERN, message: '1~10자 한글, 영어만 가능합니다.' },
+              })}
+            />
+            {errors.name && <p className='text-xs mt-1 mx-1 flex items-center text-error'>{errors.name.message}</p>}
+          </div>
           <Button className='w-full' data-testid='signUpBtn'>
             회원가입
           </Button>

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -1,16 +1,53 @@
 import React from 'react';
+import { useForm } from 'react-hook-form';
 import { Button, Input } from '@material-tailwind/react';
 import { ReactComponent as TextLogo } from '@assets/images/logo/textLogo.svg';
+import { EMAIL_PATTERN, NAME_PATTERN, PASSWORD_PATTERN } from '@constants/validationPatterns';
+import { REQUIRE_ERROR_MSG } from '@constants/errorMsg';
+
+interface SignUpInputs {
+  email: string;
+  password: string;
+  name: string;
+}
 
 const SignUpPage = () => {
+  const { register } = useForm<SignUpInputs>();
+
   return (
     <div className='flex min-h-full flex-col justify-center px-8'>
       <div className='mx-auto space-y-4 w-full shadow max-w-[450px] px-16 pt-9 pb-16'>
         <TextLogo className='w-36 m-auto mb-8' data-testid='textLogo' />
         <form className='space-y-12'>
-          <Input label='이메일' crossOrigin='' data-testid='email' />
-          <Input label='비밀번호' type='password' crossOrigin='' data-testid='password' />
-          <Input label='이름' crossOrigin='' data-testid='name' />
+          <Input
+            label='이메일'
+            type='email'
+            crossOrigin=''
+            data-testid='email'
+            {...register('email', {
+              required: REQUIRE_ERROR_MSG,
+              pattern: { value: EMAIL_PATTERN, message: '이메일 주소를 다시 확인해주세요.' },
+            })}
+          />
+          <Input
+            label='비밀번호'
+            type='password'
+            crossOrigin=''
+            data-testid='password'
+            {...register('password', {
+              required: REQUIRE_ERROR_MSG,
+              pattern: { value: PASSWORD_PATTERN, message: '8~20자 영문과 숫자를 사용하세요.' },
+            })}
+          />
+          <Input
+            label='이름'
+            crossOrigin=''
+            data-testid='name'
+            {...register('name', {
+              required: REQUIRE_ERROR_MSG,
+              pattern: { value: NAME_PATTERN, message: '1~10자 한글, 영어만 가능합니다.' },
+            })}
+          />
           <Button className='w-full' data-testid='signUpBtn'>
             회원가입
           </Button>

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -3,7 +3,7 @@ import { FieldValues, SubmitHandler, useForm } from 'react-hook-form';
 import { Button, Input } from '@material-tailwind/react';
 import { ReactComponent as TextLogo } from '@assets/images/logo/textLogo.svg';
 import { EMAIL_PATTERN, NAME_PATTERN, PASSWORD_PATTERN } from '@constants/validationPatterns';
-import { REQUIRE_ERROR_MSG } from '@constants/errorMsg';
+import { EMAIL_ERROR_MSG, NAME_ERROR_MSG, PASSWORD_ERROR_MSG, REQUIRE_ERROR_MSG } from '@constants/errorMsg';
 import { useMutation } from '@tanstack/react-query';
 import { signUpFn } from '@apis/authApi';
 import { useNavigate } from 'react-router-dom';
@@ -48,7 +48,7 @@ const SignUpPage = () => {
               data-testid='email'
               {...register('email', {
                 required: REQUIRE_ERROR_MSG,
-                pattern: { value: EMAIL_PATTERN, message: '이메일 형식이 맞지 않습니다.' },
+                pattern: { value: EMAIL_PATTERN, message: EMAIL_ERROR_MSG },
               })}
             />
             {errors.email && <p className='text-xs mt-1 mx-1 flex items-center text-error'>{errors.email.message}</p>}
@@ -61,7 +61,7 @@ const SignUpPage = () => {
               data-testid='password'
               {...register('password', {
                 required: REQUIRE_ERROR_MSG,
-                pattern: { value: PASSWORD_PATTERN, message: '8~20자 영문과 숫자를 사용하세요.' },
+                pattern: { value: PASSWORD_PATTERN, message: PASSWORD_ERROR_MSG },
               })}
             />
             {errors.password && (
@@ -75,7 +75,7 @@ const SignUpPage = () => {
               data-testid='name'
               {...register('name', {
                 required: REQUIRE_ERROR_MSG,
-                pattern: { value: NAME_PATTERN, message: '1~10자 한글, 영어만 가능합니다.' },
+                pattern: { value: NAME_PATTERN, message: NAME_ERROR_MSG },
               })}
             />
             {errors.name && <p className='text-xs mt-1 mx-1 flex items-center text-error'>{errors.name.message}</p>}

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -14,7 +14,7 @@ interface SignUpInputs {
 const SignUpPage = () => {
   const {
     register,
-    formState: { errors },
+    formState: { errors, isValid },
   } = useForm<SignUpInputs>({ mode: 'onChange' });
 
   return (
@@ -62,7 +62,7 @@ const SignUpPage = () => {
             />
             {errors.name && <p className='text-xs mt-1 mx-1 flex items-center text-error'>{errors.name.message}</p>}
           </div>
-          <Button className='w-full' data-testid='signUpBtn'>
+          <Button className='w-full' data-testid='signUpBtn' disabled={!isValid}>
             회원가입
           </Button>
         </form>

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
-import { useForm } from 'react-hook-form';
+import { FieldValues, SubmitHandler, useForm } from 'react-hook-form';
 import { Button, Input } from '@material-tailwind/react';
 import { ReactComponent as TextLogo } from '@assets/images/logo/textLogo.svg';
 import { EMAIL_PATTERN, NAME_PATTERN, PASSWORD_PATTERN } from '@constants/validationPatterns';
 import { REQUIRE_ERROR_MSG } from '@constants/errorMsg';
+import { useMutation } from '@tanstack/react-query';
+import { signUpFn } from '@apis/authApi';
+import { useNavigate } from 'react-router-dom';
 
 interface SignUpInputs {
   email: string;
@@ -14,14 +17,29 @@ interface SignUpInputs {
 const SignUpPage = () => {
   const {
     register,
+    handleSubmit,
     formState: { errors, isValid },
   } = useForm<SignUpInputs>({ mode: 'onChange' });
+  const navigate = useNavigate();
+
+  const { mutate: signUp } = useMutation({ mutationFn: signUpFn });
+
+  const handleSignUpSubmit: SubmitHandler<FieldValues> = ({ email, password, name }) => {
+    signUp(
+      { email, password, name },
+      {
+        onSuccess: () => {
+          navigate('/login');
+        },
+      },
+    );
+  };
 
   return (
     <div className='flex min-h-full flex-col justify-center px-8'>
       <div className='mx-auto space-y-4 w-full shadow max-w-[450px] px-16 pt-9 pb-16'>
         <TextLogo className='w-36 m-auto mb-8' data-testid='textLogo' />
-        <form className='space-y-12'>
+        <form className='space-y-12' onSubmit={handleSubmit(handleSignUpSubmit)}>
           <div>
             <Input
               label='이메일'
@@ -62,7 +80,7 @@ const SignUpPage = () => {
             />
             {errors.name && <p className='text-xs mt-1 mx-1 flex items-center text-error'>{errors.name.message}</p>}
           </div>
-          <Button className='w-full' data-testid='signUpBtn' disabled={!isValid}>
+          <Button type='submit' className='w-full' data-testid='signUpBtn' disabled={!isValid}>
             회원가입
           </Button>
         </form>

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -3,7 +3,13 @@ import { FieldValues, SubmitHandler, useForm } from 'react-hook-form';
 import { Button, Input } from '@material-tailwind/react';
 import { ReactComponent as TextLogo } from '@assets/images/logo/textLogo.svg';
 import { EMAIL_PATTERN, NAME_PATTERN, PASSWORD_PATTERN } from '@constants/validationPatterns';
-import { EMAIL_ERROR_MSG, NAME_ERROR_MSG, PASSWORD_ERROR_MSG, REQUIRE_ERROR_MSG } from '@constants/errorMsg';
+import {
+  EMAIL_ERROR_MSG,
+  NAME_ERROR_MSG,
+  PASSWORD_ERROR_MSG,
+  REQUIRE_ERROR_MSG,
+  PASSWORD_CONFIRM_ERROR_MSG,
+} from '@constants/errorMsg';
 import { useMutation } from '@tanstack/react-query';
 import { signUpFn } from '@apis/authApi';
 import { useNavigate } from 'react-router-dom';
@@ -11,6 +17,7 @@ import { useNavigate } from 'react-router-dom';
 interface SignUpInputs {
   email: string;
   password: string;
+  passwordConfirm: string;
   name: string;
 }
 
@@ -18,6 +25,7 @@ const SignUpPage = () => {
   const {
     register,
     handleSubmit,
+    getValues,
     formState: { errors, isValid },
   } = useForm<SignUpInputs>({ mode: 'onChange' });
   const navigate = useNavigate();
@@ -66,6 +74,26 @@ const SignUpPage = () => {
             />
             {errors.password && (
               <p className='text-xs mt-1 mx-1 flex items-center text-error'>{errors.password.message}</p>
+            )}
+          </div>
+          <div>
+            <Input
+              label='비밀번호 확인'
+              type='password'
+              crossOrigin=''
+              data-testid='passwordConfirm'
+              {...register('passwordConfirm', {
+                required: REQUIRE_ERROR_MSG,
+                validate: {
+                  confirmMatchPassward: (value) => {
+                    if (getValues('password') !== value) return PASSWORD_CONFIRM_ERROR_MSG;
+                    return undefined;
+                  },
+                },
+              })}
+            />
+            {errors.passwordConfirm && (
+              <p className='text-xs mt-1 mx-1 flex items-center text-error'>{errors.passwordConfirm.message}</p>
             )}
           </div>
           <div>

--- a/src/test/pages/LoginPage.test.tsx
+++ b/src/test/pages/LoginPage.test.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import LoginPage from '@pages/LoginPage';
-import { BrowserRouter } from 'react-router-dom';
+import TestWrapper from '@test/utils/TestWrapper';
 
 describe('로그인', () => {
   describe('UI 컴포넌트 렌더링', () => {
     it('텍스트 로고 렌더링 성공', () => {
       render(
-        <BrowserRouter>
+        <TestWrapper>
           <LoginPage />
-        </BrowserRouter>,
+        </TestWrapper>,
       );
 
       const textLogoElement = screen.getByTestId('textLogo');
@@ -18,9 +18,9 @@ describe('로그인', () => {
     });
     it('이메일 인풋 렌더링 성공', () => {
       render(
-        <BrowserRouter>
+        <TestWrapper>
           <LoginPage />
-        </BrowserRouter>,
+        </TestWrapper>,
       );
 
       const emailInputElement = screen.getByTestId('email');
@@ -29,9 +29,9 @@ describe('로그인', () => {
     });
     it('비밀번호 인풋 렌더링 성공', () => {
       render(
-        <BrowserRouter>
+        <TestWrapper>
           <LoginPage />
-        </BrowserRouter>,
+        </TestWrapper>,
       );
 
       const passwordInputElement = screen.getByTestId('password');
@@ -40,9 +40,9 @@ describe('로그인', () => {
     });
     it('로그인 버튼 렌더링 성공', () => {
       render(
-        <BrowserRouter>
+        <TestWrapper>
           <LoginPage />
-        </BrowserRouter>,
+        </TestWrapper>,
       );
 
       const loginBtnElement = screen.getByTestId('loginBtn');
@@ -51,9 +51,9 @@ describe('로그인', () => {
     });
     it('회원가입 이동 링크 렌더링 성공', () => {
       render(
-        <BrowserRouter>
+        <TestWrapper>
           <LoginPage />
-        </BrowserRouter>,
+        </TestWrapper>,
       );
 
       const signUpLinkElement = screen.getByTestId('signUpLink');
@@ -62,9 +62,9 @@ describe('로그인', () => {
     });
     it('비밀번호 찾기 이동 링크 렌더링 성공', () => {
       render(
-        <BrowserRouter>
+        <TestWrapper>
           <LoginPage />
-        </BrowserRouter>,
+        </TestWrapper>,
       );
 
       const passwordFindLinkElement = screen.getByTestId('passwordFindLink');
@@ -73,9 +73,9 @@ describe('로그인', () => {
     });
     it('카카오톡으로 로그인 버튼 렌더링 성공', () => {
       render(
-        <BrowserRouter>
+        <TestWrapper>
           <LoginPage />
-        </BrowserRouter>,
+        </TestWrapper>,
       );
 
       const kakaoLoginBtnElement = screen.getByTestId('kakaoLoginBtn');

--- a/src/test/pages/SignUpPage.test.tsx
+++ b/src/test/pages/SignUpPage.test.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import SignUpPage from '@pages/SignUpPage';
-import { BrowserRouter } from 'react-router-dom';
+import TestWrapper from '@test/utils/TestWrapper';
 
 describe('회원가입', () => {
   describe('UI 컴포넌트 렌더링', () => {
     it('텍스트 로고 렌더링 성공', () => {
       render(
-        <BrowserRouter>
+        <TestWrapper>
           <SignUpPage />
-        </BrowserRouter>,
+        </TestWrapper>,
       );
       const textLogoElement = screen.getByTestId('textLogo');
 
@@ -17,9 +17,9 @@ describe('회원가입', () => {
     });
     it('이메일 인풋 렌더링 성공', () => {
       render(
-        <BrowserRouter>
+        <TestWrapper>
           <SignUpPage />
-        </BrowserRouter>,
+        </TestWrapper>,
       );
       const emailInputElement = screen.getByTestId('email');
 
@@ -27,9 +27,9 @@ describe('회원가입', () => {
     });
     it('비밀번호 인풋 렌더링 성공', () => {
       render(
-        <BrowserRouter>
+        <TestWrapper>
           <SignUpPage />
-        </BrowserRouter>,
+        </TestWrapper>,
       );
       const passwordInputElement = screen.getByTestId('password');
 
@@ -37,9 +37,9 @@ describe('회원가입', () => {
     });
     it('이름 인풋 렌더링 성공', () => {
       render(
-        <BrowserRouter>
+        <TestWrapper>
           <SignUpPage />
-        </BrowserRouter>,
+        </TestWrapper>,
       );
       const nameInputElement = screen.getByTestId('name');
 
@@ -47,9 +47,9 @@ describe('회원가입', () => {
     });
     it('회원가입 버튼 렌더링 성공', () => {
       render(
-        <BrowserRouter>
+        <TestWrapper>
           <SignUpPage />
-        </BrowserRouter>,
+        </TestWrapper>,
       );
       const signUpBtnInputElement = screen.getByTestId('signUpBtn');
 

--- a/src/test/pages/SignUpPage.test.tsx
+++ b/src/test/pages/SignUpPage.test.tsx
@@ -1,35 +1,56 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import SignUpPage from '@pages/SignUpPage';
+import { BrowserRouter } from 'react-router-dom';
 
 describe('회원가입', () => {
   describe('UI 컴포넌트 렌더링', () => {
     it('텍스트 로고 렌더링 성공', () => {
-      render(<SignUpPage />);
+      render(
+        <BrowserRouter>
+          <SignUpPage />
+        </BrowserRouter>,
+      );
       const textLogoElement = screen.getByTestId('textLogo');
 
       expect(textLogoElement).toBeInTheDocument();
     });
     it('이메일 인풋 렌더링 성공', () => {
-      render(<SignUpPage />);
+      render(
+        <BrowserRouter>
+          <SignUpPage />
+        </BrowserRouter>,
+      );
       const emailInputElement = screen.getByTestId('email');
 
       expect(emailInputElement).toBeInTheDocument();
     });
     it('비밀번호 인풋 렌더링 성공', () => {
-      render(<SignUpPage />);
+      render(
+        <BrowserRouter>
+          <SignUpPage />
+        </BrowserRouter>,
+      );
       const passwordInputElement = screen.getByTestId('password');
 
       expect(passwordInputElement).toBeInTheDocument();
     });
     it('이름 인풋 렌더링 성공', () => {
-      render(<SignUpPage />);
+      render(
+        <BrowserRouter>
+          <SignUpPage />
+        </BrowserRouter>,
+      );
       const nameInputElement = screen.getByTestId('name');
 
       expect(nameInputElement).toBeInTheDocument();
     });
     it('회원가입 버튼 렌더링 성공', () => {
-      render(<SignUpPage />);
+      render(
+        <BrowserRouter>
+          <SignUpPage />
+        </BrowserRouter>,
+      );
       const signUpBtnInputElement = screen.getByTestId('signUpBtn');
 
       expect(signUpBtnInputElement).toBeInTheDocument();

--- a/src/test/pages/SignUpPage.test.tsx
+++ b/src/test/pages/SignUpPage.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import SignUpPage from '@pages/SignUpPage';
 import TestWrapper from '@test/utils/TestWrapper';
-import { EMAIL_ERROR_MSG, NAME_ERROR_MSG, PASSWORD_ERROR_MSG } from '@constants/errorMsg';
+import { EMAIL_ERROR_MSG, NAME_ERROR_MSG, PASSWORD_CONFIRM_ERROR_MSG, PASSWORD_ERROR_MSG } from '@constants/errorMsg';
 
 describe('회원가입', () => {
   describe('UI 컴포넌트 렌더링', () => {
@@ -35,6 +35,16 @@ describe('회원가입', () => {
       const passwordInputElement = screen.getByTestId('password');
 
       expect(passwordInputElement).toBeInTheDocument();
+    });
+    it('비밀번호 확인 인풋 렌더링 성공', () => {
+      render(
+        <TestWrapper>
+          <SignUpPage />
+        </TestWrapper>,
+      );
+      const passwordConfirmInputElement = screen.getByTestId('passwordConfirm');
+
+      expect(passwordConfirmInputElement).toBeInTheDocument();
     });
     it('이름 인풋 렌더링 성공', () => {
       render(
@@ -90,7 +100,27 @@ describe('회원가입', () => {
       const passwordErrorMessage = await screen.findByText(PASSWORD_ERROR_MSG);
       expect(passwordErrorMessage).toBeInTheDocument();
     });
+    it('비밀번호와 비밀번호 확인이 다른 경우, 오류 메시지가 표시되어야 함', async () => {
+      render(
+        <TestWrapper>
+          <SignUpPage />
+        </TestWrapper>,
+      );
 
+      const VALID_PASSWORD = '12345678a!';
+      const DIFFERENT_PASSWORD = `!${VALID_PASSWORD}`;
+
+      // 비밀번호와 비밀번호 확인 필드 입력
+      const passwordInputElement = screen.getByTestId('password');
+      const confirmPasswordInputElement = screen.getByTestId('passwordConfirm');
+
+      fireEvent.input(passwordInputElement, { target: { value: VALID_PASSWORD } });
+      fireEvent.input(confirmPasswordInputElement, { target: { value: DIFFERENT_PASSWORD } });
+
+      // 오류 메시지가 표시되는지 확인
+      const passwordCormfirmErrorMessage = await screen.findByText(PASSWORD_CONFIRM_ERROR_MSG);
+      expect(passwordCormfirmErrorMessage).toBeInTheDocument();
+    });
     it('이름 형식이 잘못된 경우, 오류 메시지가 표시되어야 함', async () => {
       render(
         <TestWrapper>

--- a/src/test/pages/SignUpPage.test.tsx
+++ b/src/test/pages/SignUpPage.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import SignUpPage from '@pages/SignUpPage';
 import TestWrapper from '@test/utils/TestWrapper';
+import { EMAIL_ERROR_MSG, NAME_ERROR_MSG, PASSWORD_ERROR_MSG } from '@constants/errorMsg';
 
 describe('회원가입', () => {
   describe('UI 컴포넌트 렌더링', () => {
@@ -54,6 +55,57 @@ describe('회원가입', () => {
       const signUpBtnInputElement = screen.getByTestId('signUpBtn');
 
       expect(signUpBtnInputElement).toBeInTheDocument();
+    });
+  });
+  describe('유효성 검증', () => {
+    it('이메일 형식이 잘못된 경우, 오류 메시지가 표시되어야 함', async () => {
+      render(
+        <TestWrapper>
+          <SignUpPage />
+        </TestWrapper>,
+      );
+
+      // 유효하지 않은 이메일 형식 입력
+      const INVALID_EMAIL = 'invalid-email';
+      const emailInputElement = screen.getByTestId('email');
+      fireEvent.change(emailInputElement, { target: { value: INVALID_EMAIL } });
+
+      // 이메일 형식 오류 메시지 확인
+      const emailErrorMessage = await screen.findByText(EMAIL_ERROR_MSG);
+      expect(emailErrorMessage).toBeInTheDocument();
+    });
+    it('비밀번호 형식이 잘못된 경우, 오류 메시지가 표시되어야 함', async () => {
+      render(
+        <TestWrapper>
+          <SignUpPage />
+        </TestWrapper>,
+      );
+
+      // 유효하지 않은 비밀번호 형식 입력
+      const INVALID_PASSWORD = 'short';
+      const passwordInputElement = screen.getByTestId('password');
+      fireEvent.change(passwordInputElement, { target: { value: INVALID_PASSWORD } });
+
+      // 비밀번호 형식 오류 메시지 확인
+      const passwordErrorMessage = await screen.findByText(PASSWORD_ERROR_MSG);
+      expect(passwordErrorMessage).toBeInTheDocument();
+    });
+
+    it('이름 형식이 잘못된 경우, 오류 메시지가 표시되어야 함', async () => {
+      render(
+        <TestWrapper>
+          <SignUpPage />
+        </TestWrapper>,
+      );
+
+      // 유효하지 않은 이름 형식 입력
+      const INVALID_NAME = '1234567890';
+      const nameInputElement = screen.getByTestId('name');
+      fireEvent.change(nameInputElement, { target: { value: INVALID_NAME } });
+
+      // 이름 형식 오류 메시지 확인
+      const nameErrorMessage = await screen.findByText(NAME_ERROR_MSG);
+      expect(nameErrorMessage).toBeInTheDocument();
     });
   });
 });

--- a/src/test/utils/TestWrapper.tsx
+++ b/src/test/utils/TestWrapper.tsx
@@ -1,9 +1,15 @@
 /* eslint-disable import/prefer-default-export */
+import { queryClient } from '@apis/queryClient';
+import { QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 
 const TestWrapper = ({ children }: { children: React.ReactNode }) => {
-  return <BrowserRouter>{children}</BrowserRouter>;
+  return (
+    <BrowserRouter>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </BrowserRouter>
+  );
 };
 
 export default TestWrapper;

--- a/src/test/utils/TestWrapper.tsx
+++ b/src/test/utils/TestWrapper.tsx
@@ -1,0 +1,9 @@
+/* eslint-disable import/prefer-default-export */
+import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+
+const TestWrapper = ({ children }: { children: React.ReactNode }) => {
+  return <BrowserRouter>{children}</BrowserRouter>;
+};
+
+export default TestWrapper;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,6 +2,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 /** @type {import('tailwindcss').Config} */
 const withMT = require('@material-tailwind/react/utils/withMT');
+const colors = require('tailwindcss/colors');
 
 module.exports = withMT({
   content: ['./src/**/*.{js,jsx,ts,tsx}'],
@@ -11,6 +12,7 @@ module.exports = withMT({
         kakaoContainer: '#FEE500',
         kakaoSymbol: '#000000',
         kakaoLabel: '#000000D9',
+        error: colors.red[500],
       },
       fontFamily: {
         sans: ['NanumSquare', 'sans-serif'],

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -7,7 +7,8 @@
       "@pages/*": ["src/pages/*"],
       "@recoil/*": ["src/recoil/*"],
       "@test/*": ["src/test/*"],
-      "@dummy/*": ["src/dummy/*"]
+      "@dummy/*": ["src/dummy/*"],
+      "@constants/*": ["src/constants/*"]
     }
   }
 }

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -8,7 +8,8 @@
       "@recoil/*": ["src/recoil/*"],
       "@test/*": ["src/test/*"],
       "@dummy/*": ["src/dummy/*"],
-      "@constants/*": ["src/constants/*"]
+      "@constants/*": ["src/constants/*"],
+      "@apis/*": ["src/apis/*"]
     }
   }
 }


### PR DESCRIPTION
## ⭐Key Changes
- api 호출을 위한 기반 작업을 해두었습니다.
  - axios 인스턴스 생성
  - queryKey 관리하는 파일 생성
  - gitignore에 env 파일 추가
- 회원가입 기능 구현하였습니다.
  - 각 인풋 필드별 유효성 검사
  - onChange 시 에러 메시지 처리
  - 유효하지 않은 상태일 때 회원가입 버튼 비활성화 처리
  - 회원가입 성공 시 로그인 페이지로 리다이렉트
- 회원가입 유효성 관련 테스트 코드 작성하였습니다.

## 📌Issue
- Close #24, Close #99 


## 👪To Reviewers
- 구조랑 이것저것 생각하다보니 시간이 많이 걸렸네요..! ㅎㅎ
### 파일 구조 추가된 사항입니다.
  <pre>
  <b>src</b>
   ┣ <b>apis</b> : api 관련 파일을 모아두는 폴더입니다.
   ┃ ┣ <b>authApi.ts</b> : api 명세서의 도메인 별 api를 한 파일에 모아 사용하며, 파일 네이밍 또한 도메인을 따릅니다. (아래 설명1 참고)
   ┃ ┣ <b>axios.ts</b> : axios 인스턴스를 정의해둔 파일입니다.
   ┃ ┗ <b>queryClient.ts</b> : queryClient를 정의해둔 파일입니다. (아래 설명2 참고)
   ┗ <b>constants</b> : 상수들을 관리하는 파일을 모아두는 폴더입니다.
     ┣ <b>errorMsg.ts</b> : 에러 메시지 문자열들을 관리하는 파일입니다.
     ┣ <b>queryKeys.ts</b> : react-query queryKey들을 관리하는 파일입니다.
     ┗ <b>validationPatterns.ts</b> : 유효성 검사에 사용되는 패턴(/정규식)을 관리하는 파일입니다.
  </pre>
  - 설명 1
    - <img width="300" alt="image" src="https://github.com/Step3-kakao-tech-campus/Team8_FE/assets/78250089/414a6f20-586b-4b22-9db8-2447e0deebbc">
    - 명세서 상 사용자 API의 `auth` 도메인에 해당하는 api는 모두 `authApi.ts` 파일 내에서 관리됩니다.
  - 설명 2
    - 회의 때 queryClient랑 query key같은 파일에서 관리하자는 의견이 나왔으나, query key의 경우 상수로 분류되어 사용하는 게 구조가 직관적일 것 같아 `constants` 폴더 하위로 구성하면서 queryClient는 별도의 파일로 분리하여 구성하였습니다.

### API 관련 
- api 사용할 때 `baseUrl`을 위한 `.env` 파일이 필요합니다. 이건 서버 주소 노출을 막기위해 카톡으로 전달드리겠습니다!
- api 작성 시 공통적으로 포함되는 도메인에 해당하는 string은 `ENDPOINT`라는 상수로 지정하여 공통적으로 처리해주었습니다.
  <img width="656" alt="image" src="https://github.com/Step3-kakao-tech-campus/Team8_FE/assets/78250089/49f045b1-e464-4b48-a187-8caf36facb90">

### form 관련
- form 관리를 더 쉽고, 간편하기 위해 `react-hook-form` 라이브러리를 설치하여 사용하였습니다.
- 유효성 검사는 `onChange` 이벤트 발생 시마다 검사하도록 하였고, 모든 유효성이 valid해야 회원가입 버튼이 활성화되도록 하였습니다.

### 기타
- tailwind 색상에 `error` 색상 추가하였습니다. 성공, 에러 관련 색상은 통일해서 사용하면 좋을 것 같아서 tailwind의 `red-500`에 해당하는 생상을 에러 색상으로 커스텀 해두었고, `text-error`와 같은 식으로 사용 가능합니다. (나중에 성공 색상 사용할 일 있으면 공통적으로 처리해주면 좋을 것 같아요!)
- 테스트 코드는 더 많은 테스트 같이 해보고 싶었는데, 시간 너무 많이 잡아먹을 것 같아서 하는 만큼만하고 막혔을 때 과감하게 나머지는 버렸습니다..! ㅎㅎ 더 하고 싶은 건 시간 날 때 하는 걸로...

## 🎥Preview

https://github.com/Step3-kakao-tech-campus/Team8_FE/assets/78250089/1faa9fd7-d57e-428f-936d-7810ac85c187



## 🐾Next Move
- 로그인 기능은 이 PR 머지되면 바로 작업해올리겠습니다!
- 카카오 로그인 관련해서는 바로 작업은 어려울 것 같고, 일요일 밤이나 월요일 중으로 해질 것 같아요..!
