### PR TITLE
리스트 key값 uuid 사용해서 고유한 값으로 설정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@types/node": "^16.18.54",
         "@types/react": "^18.2.22",
         "@types/react-dom": "^18.2.7",
+        "@types/uuid": "^9.0.6",
         "axios": "^1.5.0",
         "ckeditor5-custom-build": "file:ckeditor5",
         "cross-env": "^7.0.3",
@@ -5532,6 +5533,11 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.4.tgz",
       "integrity": "sha512-IDaobHimLQhjwsQ/NMwRVfa/yL7L/wriQPMhw1ZJall0KX6E1oxk29XMDeilW5qTIg5aoiqf5Udy8U/51aNoQQ=="
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.6.tgz",
+      "integrity": "sha512-BT2Krtx4xaO6iwzwMFUYvWBWkV2pr37zD68Vmp1CDV196MzczBRxuEpD6Pr395HAgebC/co7hOphs53r8V7jew=="
     },
     "node_modules/@types/ws": {
       "version": "8.5.6",
@@ -24813,6 +24819,11 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.4.tgz",
       "integrity": "sha512-IDaobHimLQhjwsQ/NMwRVfa/yL7L/wriQPMhw1ZJall0KX6E1oxk29XMDeilW5qTIg5aoiqf5Udy8U/51aNoQQ=="
+    },
+    "@types/uuid": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.6.tgz",
+      "integrity": "sha512-BT2Krtx4xaO6iwzwMFUYvWBWkV2pr37zD68Vmp1CDV196MzczBRxuEpD6Pr395HAgebC/co7hOphs53r8V7jew=="
     },
     "@types/ws": {
       "version": "8.5.6",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@types/node": "^16.18.54",
     "@types/react": "^18.2.22",
     "@types/react-dom": "^18.2.7",
+    "@types/uuid": "^9.0.6",
     "axios": "^1.5.0",
     "ckeditor5-custom-build": "file:ckeditor5",
     "cross-env": "^7.0.3",

--- a/src/components/CommentList.tsx
+++ b/src/components/CommentList.tsx
@@ -1,6 +1,7 @@
 import React, { ChangeEvent, RefObject, useState } from 'react';
 import { Collapse, Textarea } from '@material-tailwind/react';
 import { MdSend, MdOutlineKeyboardArrowUp } from 'react-icons/md';
+import { v4 as uuidv4 } from 'uuid';
 import Comment from './Comment';
 
 interface Comment {
@@ -35,7 +36,7 @@ const CommentList = ({ commentRef, isOpen, onCommentClose, comments }: CommentLi
       <p className='pt-4 pl-4 font-bold border-t'>댓글 {comments.length}</p>
       <ul className='flex flex-col gap-5 p-4'>
         {comments.map((comment) => (
-          <Comment key={comment.commentId} comment={comment} />
+          <Comment key={uuidv4()} comment={comment} />
         ))}
       </ul>
       <div className='relative flex gap-3 p-4 border-t'>

--- a/src/components/ContributeAccordion.tsx
+++ b/src/components/ContributeAccordion.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Accordion, AccordionHeader, AccordionBody } from '@material-tailwind/react';
+import { v4 as uuidv4 } from 'uuid';
 import { groupMyPageDummyData } from '@dummy/group';
 
 const ContributeAccordion = () => {
@@ -11,7 +12,7 @@ const ContributeAccordion = () => {
     <>
       {groupMyPageDummyData.historyList.map((data) => (
         <Accordion
-          key={data.historyId}
+          key={uuidv4()}
           open={open === data.historyId}
           className='mb-2 rounded-sm border border-blue-gray-100 px-4'
           icon={<span className='text-sm text-gray-400 font-normal'>{data.createAt}</span>}

--- a/src/components/ContributeList.tsx
+++ b/src/components/ContributeList.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { v4 as uuidv4 } from 'uuid';
 import ContributeItem from './ContributeItem';
 
 interface ContributeItemContent {
@@ -19,7 +20,7 @@ const ContributeList = ({ contributeItems }: { contributeItems: ContributeItemPr
     <article className='p-4 max-h-[503px] border border-gray-400 overflow-y-auto'>
       <ul className='flex flex-col gap-4'>
         {contributeItems.slice(0, 3).map((contributeItem) => (
-          <ContributeItem key={contributeItem.historyId} contributeItem={contributeItem} />
+          <ContributeItem key={uuidv4()} contributeItem={contributeItem} />
         ))}
       </ul>
     </article>

--- a/src/components/GroupList.tsx
+++ b/src/components/GroupList.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { v4 as uuidv4 } from 'uuid';
 import GroupCard from './GroupCard';
 
 interface Group {
@@ -11,7 +12,7 @@ const GroupList = ({ groups }: { groups: Group[] }) => {
   return (
     <div className='grid grid-cols-4 gap-4 p-0'>
       {groups.map((item) => (
-        <GroupCard key={item.groupId} group={item} />
+        <GroupCard key={uuidv4()} group={item} />
       ))}
     </div>
   );

--- a/src/components/GroupSelector.tsx
+++ b/src/components/GroupSelector.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Select, Option } from '@material-tailwind/react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { v4 as uuidv4 } from 'uuid';
 import { unOfficialGroupDummyData } from '@dummy/group';
 
 const GroupSelector = () => {
@@ -15,7 +16,7 @@ const GroupSelector = () => {
     <div className='w-52'>
       <Select label='그룹 선택' value={groupName} onChange={handleChange}>
         {unOfficialGroupDummyData.map((group) => (
-          <Option key={group.groupId} value={group.groupName}>
+          <Option key={uuidv4()} value={group.groupName}>
             {group.groupName}
           </Option>
         ))}

--- a/src/components/IndexList.tsx
+++ b/src/components/IndexList.tsx
@@ -1,5 +1,6 @@
-import { getIndexList } from '@dummy/page';
 import React from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import { getIndexList } from '@dummy/page';
 
 interface IndexListProps {
   pageId: number;
@@ -13,7 +14,7 @@ const IndexList = ({ pageId }: IndexListProps) => {
       <h2 className='font-bold px-1 py-2 text-sm'>목차</h2>
       <ul className='p-4 bg-gray-100 text-xs'>
         {indexList.map((post) => (
-          <li key={post.index} className='my-2 leading-tight whitespace-pre'>
+          <li key={uuidv4()} className='my-2 leading-tight whitespace-pre'>
             {post.index.split('.').length > 2 && '  '}
             <span className='text-indigo-500'>{post.index}</span> {post.postTitle}
           </li>

--- a/src/components/OfficialGroup.tsx
+++ b/src/components/OfficialGroup.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import { Carousel } from '@material-tailwind/react';
-import { officialGroupDummyData } from '@dummy/group';
 import { Link } from 'react-router-dom';
+import { v4 as uuidv4 } from 'uuid';
+import { officialGroupDummyData } from '@dummy/group';
 
 const OfficialGroup = () => {
   return (
     <Carousel className='rounded-xl max-w-[768px]' loop>
       {officialGroupDummyData.map((group) => (
-        <Link to={`/${group.groupName}`} key={group.groupId}>
+        <Link to={`/${group.groupName}`} key={uuidv4()}>
           <div key={group.groupId} className='relative h-full w-full'>
             <img src={group.groupImage} alt={group.groupName} className='w-full h-40 object-cover mx-auto' />
             <div className='absolute inset-0 grid h-full w-full place-items-center bg-black/50'>

--- a/src/components/RecentChangeList.tsx
+++ b/src/components/RecentChangeList.tsx
@@ -1,5 +1,6 @@
-import { recentChangePageDummyData } from '@dummy/page';
 import React from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import { recentChangePageDummyData } from '@dummy/page';
 
 const RecentChangeList = () => {
   return (
@@ -7,7 +8,7 @@ const RecentChangeList = () => {
       <h2 className='font-bold px-1 py-2 text-sm'>최근 변경된 페이지</h2>
       <ul className='p-4 bg-gray-100 text-xs'>
         {recentChangePageDummyData.map((page) => (
-          <li key={page.pageId} className='my-2 leading-tight'>
+          <li key={uuidv4()} className='my-2 leading-tight'>
             {page.pageName}
           </li>
         ))}

--- a/src/pages/GroupCreatePage.tsx
+++ b/src/pages/GroupCreatePage.tsx
@@ -1,11 +1,12 @@
 import React, { useState } from 'react';
 import { Button, Step, Stepper } from '@material-tailwind/react';
+import { v4 as uuidv4 } from 'uuid';
+import { MdKeyboardArrowLeft } from 'react-icons/md';
 import GroupCreateNameSection from '@components/GroupCreate/GroupCreateNameSection';
 import GroupCreatePhotoSection from '@components/GroupCreate/GroupCreatePhotoSection';
 import GroupCreateNickNameSection from '@components/GroupCreate/GroupCreateNickNameSection';
 import GroupCreateCompleteSection from '@components/GroupCreate/GroupCreateCompleteSection';
 import GroupCreateSearchSetting from '@components/GroupCreate/GroupCreateSearchSetting';
-import { MdKeyboardArrowLeft } from 'react-icons/md';
 
 const GroupCreatePage = () => {
   const [currentStep, setCurrentStep] = useState<1 | 2 | 3 | 4 | 5>(1);
@@ -47,7 +48,7 @@ const GroupCreatePage = () => {
       <Stepper className='w-40 mb-14 cursor-pointer' activeStep={currentStep - 1}>
         {Object.keys(groupCreateSections).map((step) => (
           <Step
-            key={step}
+            key={uuidv4()}
             className='w-6 h-6 text-xs bg-gray-100'
             onClick={() => setCurrentStep(parseInt(step, 10) as 1 | 2 | 3 | 4 | 5)}
           >

--- a/src/pages/GroupMainPage.tsx
+++ b/src/pages/GroupMainPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { MdArrowCircleRight } from 'react-icons/md';
-
+import { v4 as uuidv4 } from 'uuid';
 import { getPageInfo } from '@dummy/page';
 // import { getEmptyPageInfo } from '@dummy/page';
 import PageTitleSection from '@components/PageTitleSection';
@@ -31,19 +31,20 @@ const GroupMainPage = () => {
       <PageTitleSection title={pageName} aboveAdornment={<LikeDislikeButton upCount={12} downCount={7} />} />
       <PageContainer pageId={postList.length !== 0 ? pageId : undefined} hasRecentChangeList>
         {postList.length !== 0 ? (
-          postList.map((post) => (
-            <div>
-              <Post
-                key={post.postId}
-                pageId={pageId}
-                pageName={pageName}
-                index={post.index}
-                postTitle={post.postTitle}
-                content={post.content}
-              />
-              <AddPostButton />
-            </div>
-          ))
+          <ul>
+            {postList.map((post) => (
+              <li key={uuidv4()}>
+                <Post
+                  pageId={pageId}
+                  pageName={pageName}
+                  index={post.index}
+                  postTitle={post.postTitle}
+                  content={post.content}
+                />
+                <AddPostButton />
+              </li>
+            ))}
+          </ul>
         ) : (
           <article className='flex justify-between items-center p-4 bg-gray-100 rounded-lg px-4'>
             <p className='text-sm shrink-0'>

--- a/src/pages/SearchResultPage.tsx
+++ b/src/pages/SearchResultPage.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import RecentChangeList from '@components/RecentChangeList';
-import { MdArrowCircleRight } from 'react-icons/md';
-import { pageDummyData } from '@dummy/page';
-import { Button } from '@material-tailwind/react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { MdArrowCircleRight } from 'react-icons/md';
+import { v4 as uuidv4 } from 'uuid';
+import { Button } from '@material-tailwind/react';
+import RecentChangeList from '@components/RecentChangeList';
+import { pageDummyData } from '@dummy/page';
 
 const SearchResultPage = () => {
   const query = useLocation().search;
@@ -41,7 +42,7 @@ const SearchResultPage = () => {
             </div>
           ) : (
             pageDummyData.map((post) => (
-              <div key={post.pageId} className='px-2 py-8 border-b border-gray-200'>
+              <div key={uuidv4()} className='px-2 py-8 border-b border-gray-200'>
                 <h2 className='text-lg font-bold mb-1'>{post.pageName}</h2>
                 <p className='text-sm text-gray-500'>{post.content}</p>
               </div>


### PR DESCRIPTION
## ⭐Key Changes

1. 리스트 key값 uuid 사용해서 고유한 값으로 설정

<br>

## 📌Issue

- close #101 

<br>

## 👪To Reviewers

리액트의 렌더링 관점에서 제일 권장되는 방법은 백엔드에서 uuid같은 라이브러리를 사용해서 고유한 값을 만들고 그 값을 전달받아서 key 값으로 사용하는것인것 같은데, 우리 프로젝트의 경우 데이터의 추가 또는 삭제로 인한 리렌더링이 많이 일어나지 않을것같아서 uuid 라이브러리를 사용해서 프론트에서 처리했습니다.


<br>

## 🐾Next Move

recoil key 파일 분리
