### PR TITLE
그룹 가입 추가 기능

### DIFF
--- a/src/dummy/group.ts
+++ b/src/dummy/group.ts
@@ -210,3 +210,5 @@ export const groupInfoDummyData: GroupInfo = {
 };
 
 export const groupJoinPassword: string = '엔젤몬';
+
+export const groupType: 'official' | 'unofficialOpen' | 'unofficialNoOpen' = 'official';

--- a/src/pages/GroupJoinPage.tsx
+++ b/src/pages/GroupJoinPage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { groupInfoDummyData, groupJoinPassword } from '@dummy/group';
+import { groupInfoDummyData, groupJoinPassword, groupType } from '@dummy/group';
 import { Button, Input, Typography } from '@material-tailwind/react';
 import DividerWithText from '@components/Common/DividerWithText';
 import { useNavigate } from 'react-router-dom';
@@ -8,17 +8,37 @@ import { useNavigate } from 'react-router-dom';
 const GroupJoinPage = () => {
   const data = groupInfoDummyData;
   const [entranceCode, setEntranceCode] = React.useState('');
-  const navigate = useNavigate();
   const [isWrong, setIsWrong] = React.useState(false);
 
-  const handleOnChange = (event: React.ChangeEvent<HTMLInputElement>) => setEntranceCode(event.target.value);
-  const handleOnSubmit = () => {
+  const [email, setEmail] = React.useState(''); // 이메일 인증용
+  const [validatingCode, setValidatingCode] = React.useState('');
+  const [isEmailSent, setIsEmailSent] = React.useState(false);
+
+  const navigate = useNavigate();
+
+  const handleOnCodeChange = (event: React.ChangeEvent<HTMLInputElement>) => setEntranceCode(event.target.value);
+  const handleOnEmailChange = (event: React.ChangeEvent<HTMLInputElement>) => setEmail(event.target.value);
+  const handleOnValidatingCodeChange = (event: React.ChangeEvent<HTMLInputElement>) =>
+    setValidatingCode(event.target.value);
+
+  // 정답 맞는지 확인
+  const handleCodeCheck = () => {
     if (entranceCode === groupJoinPassword) {
       // TODO: 가입 완료 API 보내기
       navigate(`/${data.groupName}`);
     } else {
       setIsWrong(true);
     }
+  };
+
+  // 이메일 인증
+  const handleEmailSend = () => {
+    // TODO: 이메일 인증 API 보내기
+    setIsEmailSent(true);
+  };
+
+  const handleEmailCheck = () => {
+    // TODO: 이메일 인증 확인 API 보내기
   };
 
   return (
@@ -37,37 +57,97 @@ const GroupJoinPage = () => {
           <Typography variant='h6'>{data.groupName}</Typography>
           <p className='text-xs min-w-[400px]'>{data.introduction}</p>
         </div>
-        <div className='w-full'>
-          <DividerWithText>정답을 맞추면 가입할 수 있어요.</DividerWithText>
-        </div>
-        <form className='w-full text-center'>
-          <Typography variant='h6' className='text-sm mb-3'>
-            Q. {data.entranceHint}
-          </Typography>
-          <div className='relative flex w-full'>
-            <Input
-              type='text'
-              label='정답 입력'
-              value={entranceCode}
-              onChange={handleOnChange}
-              className='pr-20'
-              containerProps={{
-                className: 'min-w-0',
-              }}
-              crossOrigin={undefined}
-            />
-            <Button
-              size='sm'
-              color={entranceCode ? 'gray' : 'blue-gray'}
-              disabled={!entranceCode}
-              className='!absolute right-1 top-1 rounded'
-              onClick={handleOnSubmit}
-            >
-              가입하기
-            </Button>
+        {groupType === 'unofficialNoOpen' && (
+          <div className='w-full'>
+            <form className='w-full text-center'>
+              <DividerWithText>정답을 맞추면 가입할 수 있어요.</DividerWithText>
+              <Typography variant='h6' className='text-sm mb-3 mt-6'>
+                Q. {data.entranceHint}
+              </Typography>
+              <div className='relative flex w-full'>
+                <Input
+                  type='text'
+                  label='정답 입력'
+                  value={entranceCode}
+                  onChange={handleOnCodeChange}
+                  className='pr-20'
+                  containerProps={{
+                    className: 'min-w-0',
+                  }}
+                  crossOrigin={undefined}
+                />
+                <Button
+                  size='sm'
+                  color={entranceCode ? 'gray' : 'blue-gray'}
+                  disabled={!entranceCode}
+                  className='!absolute right-1 top-1 rounded'
+                  onClick={handleCodeCheck}
+                >
+                  가입하기
+                </Button>
+              </div>
+              {isWrong && <p className='text-error text-xs mt-2'>정답이 틀렸어요. 다시 입력해주세요.</p>}
+            </form>
           </div>
-          {isWrong && <p className='text-error text-xs mt-2'>정답이 틀렸어요. 다시 입력해주세요.</p>}
-        </form>
+        )}
+        {groupType === 'unofficialOpen' && <Button>가입하기</Button>}
+        {groupType === 'official' && (
+          <div className='w-full'>
+            <form className='w-full text-center'>
+              <DividerWithText>학교 인증을 진행해주세요.</DividerWithText>
+              <div className='relative flex w-full mt-6'>
+                <Input
+                  type='text'
+                  label='학교 이메일 입력'
+                  value={email}
+                  onChange={handleOnEmailChange}
+                  className='pr-20'
+                  containerProps={{
+                    className: 'min-w-0',
+                  }}
+                  crossOrigin={undefined}
+                />
+                <Button
+                  size='sm'
+                  color={email ? 'gray' : 'blue-gray'}
+                  disabled={!email}
+                  className='!absolute right-1 top-1 rounded'
+                  onClick={handleEmailSend}
+                >
+                  {isEmailSent ? '재전송' : '인증'}
+                </Button>
+              </div>
+
+              {/* TODO: 중복 이메일, 이메일 형식 오류 등 안내 메세지 출력(에러처리) */}
+              <p className='text-xs mt-2'>{isEmailSent && '인증번호를 전송했습니다.'}</p>
+
+              {isEmailSent && (
+                <div className='relative flex w-full mt-6'>
+                  <Input
+                    type='text'
+                    label='인증번호 입력'
+                    value={validatingCode}
+                    onChange={handleOnValidatingCodeChange}
+                    className='pr-20'
+                    containerProps={{
+                      className: 'min-w-0',
+                    }}
+                    crossOrigin={undefined}
+                  />
+                  <Button
+                    size='sm'
+                    color={validatingCode ? 'gray' : 'blue-gray'}
+                    disabled={!validatingCode}
+                    className='!absolute right-1 top-1 rounded'
+                    onClick={handleEmailCheck}
+                  >
+                    확인
+                  </Button>
+                </div>
+              )}
+            </form>
+          </div>
+        )}
       </div>
     </section>
   );


### PR DESCRIPTION

## ⭐Key Changes
> 핵심 변경 사항에 대해서 적어주세요.
1. 공식 그룹 이메일 인증 칸 생성
![image](https://github.com/Step3-kakao-tech-campus/Team8_FE/assets/48706964/5cf6bbc8-12b5-48c6-94fd-b222a1829ad8)
![image](https://github.com/Step3-kakao-tech-campus/Team8_FE/assets/48706964/c3ef7c3b-8b46-4087-b3ed-3f41506b27ff)


3. 비공식 검색 비허용일 때 바로 가입하기 버튼 출력
![image](https://github.com/Step3-kakao-tech-campus/Team8_FE/assets/48706964/2eb984fb-c97d-4d3d-9aeb-a94b4902f87f)


<br>

## 👪To Reviewers
생각해보니까 질문 답변하는 것만 짜고 나머지 경우를 생각 안 해서 ㅋㅋ
새벽에 부랴부랴 만들었습니다.
인증할 때 이메일 검증이나 인증 후 처리는 API 연결하면서 해줄 거라고 믿습니다... 저는 UI만 던지고 갈게요
게시글이 왕왕 많으니까...

이메일 인증하고 타이머를 출력할까 생각했는데, 우리거 유효시간 얼마인지 정보도 없고 찾아보니까 요샌 3분 제한시간 굳이 안 보여주는 UI도 종종있기에 일단 생략했습니다. 

<br>
