### PR TITLE
메인페이지 api 연결

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,18 +1,19 @@
 <!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta name="description" content="Web site created using create-react-app" />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
+<html lang="ko">
+
+<head>
+  <meta charset="utf-8" />
+  <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <meta name="description" content="Web site created using create-react-app" />
+  <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+  <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
+  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+  <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.
@@ -21,12 +22,13 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-    <!--
+  <title>React App</title>
+</head>
+
+<body>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <div id="root"></div>
+  <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.
 
@@ -36,5 +38,6 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-  </body>
+</body>
+
 </html>

--- a/src/apis/pageApi.ts
+++ b/src/apis/pageApi.ts
@@ -6,17 +6,17 @@ const token =
   'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyIiwiYXV0aCI6InVzZXIiLCJleHAiOjE2OTg3NzMxMzl9.mf9x6yoqdwgL8nRl7qjdekaP0MScAqIfEztgLkkbnnk';
 instance.defaults.headers.common.Authorization = `Bearer ${token}`;
 
-export const getPageByTitleFn = ({ groupId, title }: { groupId: string; title: string }) =>
+export const getPageByTitleFn = ({ groupId, title }: { groupId: number; title: string }) =>
   instance.get(`/group/${groupId}/page?title=${title}`);
 
-export const createPageFn = ({ groupId, pageName }: { groupId: string; pageName: string }) =>
+export const createPageFn = ({ groupId, pageName }: { groupId: number; pageName: string }) =>
   instance.post(`/group/${groupId}/page/create`, { pageName });
 
-export const getRecentChangeListFn = ({ groupId }: { groupId: string }) =>
+export const getRecentChangeListFn = ({ groupId }: { groupId: number }) =>
   instance.get(`/group/${groupId}/page/recent`);
 
-export const pageLikeFn = ({ groupId, pageId }: { groupId: string; pageId: number }) =>
+export const pageLikeFn = ({ groupId, pageId }: { groupId: number; pageId: number }) =>
   instance.post(`/group/${groupId}/page/${pageId}/like`);
 
-export const pageHateFn = ({ groupId, pageId }: { groupId: string; pageId: number }) =>
+export const pageHateFn = ({ groupId, pageId }: { groupId: number; pageId: number }) =>
   instance.post(`/group/${groupId}/page/${pageId}/hate`);

--- a/src/apis/pageApi.ts
+++ b/src/apis/pageApi.ts
@@ -2,6 +2,10 @@ import { instance } from './axios';
 
 // /group/${groupId}/page 관련 api
 
+const token =
+  'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyIiwiYXV0aCI6InVzZXIiLCJleHAiOjE2OTg3NzMxMzl9.mf9x6yoqdwgL8nRl7qjdekaP0MScAqIfEztgLkkbnnk';
+instance.defaults.headers.common.Authorization = `Bearer ${token}`;
+
 export const getPageByTitleFn = ({ groupId, title }: { groupId: string; title: string }) =>
   instance.get(`/group/${groupId}/page?title=${title}`);
 

--- a/src/apis/pageApi.ts
+++ b/src/apis/pageApi.ts
@@ -1,0 +1,18 @@
+import { instance } from './axios';
+
+// /group/${groupId}/page 관련 api
+
+export const getPageByTitleFn = ({ groupId, title }: { groupId: string; title: string }) =>
+  instance.get(`/group/${groupId}/page?title=${title}`);
+
+export const createPageFn = ({ groupId, pageName }: { groupId: string; pageName: string }) =>
+  instance.post(`/group/${groupId}/page/create`, { pageName });
+
+export const getRecentChangeListFn = ({ groupId }: { groupId: string }) =>
+  instance.get(`/group/${groupId}/page/recent`);
+
+export const pageLikeFn = ({ groupId, pageId }: { groupId: string; pageId: number }) =>
+  instance.post(`/group/${groupId}/page/${pageId}/like`);
+
+export const pageHateFn = ({ groupId, pageId }: { groupId: string; pageId: number }) =>
+  instance.post(`/group/${groupId}/page/${pageId}/hate`);

--- a/src/components/Header/HeaderMenu.tsx
+++ b/src/components/Header/HeaderMenu.tsx
@@ -5,9 +5,9 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
 import isLoggedInState from '@recoil/atoms/auth';
 import { inviteCodeDummyData } from '@dummy/group';
-import InviteModal from '../Modal/InviteModal';
 import useModal from '@hooks/useModal';
 import GroupMemberListModal from '@components/Modal/GroupMemberListModal';
+import InviteModal from '../Modal/InviteModal';
 
 const HeaderMenu = () => {
   const { groupName } = useParams();

--- a/src/components/Home/GroupCard.tsx
+++ b/src/components/Home/GroupCard.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 
 interface GroupCardProps {
   group: {
+    groupId: number;
     groupImage: string;
     groupName: string;
   };
@@ -11,7 +12,7 @@ interface GroupCardProps {
 
 const GroupCard = ({ group }: GroupCardProps) => {
   return (
-    <Link to={`/${group.groupName}`}>
+    <Link to={`/${group.groupId}/${group.groupName}`}>
       <Card className='mt-6 w-max cursor-pointer mx-auto' shadow={false}>
         <CardHeader floated={false} className='m-0'>
           <img

--- a/src/components/Page/Common/LikeDislikeButton.tsx
+++ b/src/components/Page/Common/LikeDislikeButton.tsx
@@ -5,6 +5,7 @@ import { MdThumbDown, MdThumbUp } from 'react-icons/md';
 import { useMutation } from '@tanstack/react-query';
 import { pageHateFn, pageLikeFn } from '@apis/pageApi';
 import { queryClient } from '@apis/queryClient';
+import PAGE_KEYS from '@constants/queryKeys';
 
 interface LikeDislikeButtonProps {
   goodCount: number;
@@ -21,14 +22,14 @@ const LikeDislikeButton = ({ goodCount, badCount, groupId, pageId, page }: LikeD
   const { mutate: likeMutate } = useMutation({
     mutationFn: likeMutateFn,
     onSuccess: () => {
-      queryClient.invalidateQueries(['page', { groupId, title: page }]);
+      queryClient.invalidateQueries(PAGE_KEYS.byTitle({ groupId, title: page }));
     },
   });
 
   const { mutate: dislikeMutate } = useMutation({
     mutationFn: dislikeMutateFn,
     onSuccess: () => {
-      queryClient.invalidateQueries(['page', { groupId, title: page }]);
+      queryClient.invalidateQueries(PAGE_KEYS.byTitle({ groupId, title: page }));
     },
   });
 

--- a/src/components/Page/Common/LikeDislikeButton.tsx
+++ b/src/components/Page/Common/LikeDislikeButton.tsx
@@ -1,23 +1,63 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { Button } from '@material-tailwind/react';
 import { MdThumbDown, MdThumbUp } from 'react-icons/md';
+import { useMutation } from '@tanstack/react-query';
+import { pageHateFn, pageLikeFn } from '@apis/pageApi';
 
 interface LikeDislikeButtonProps {
-  upCount: number;
-  downCount: number;
+  goodCount: number;
+  badCount: number;
+  groupId: string;
+  pageId: number;
 }
 
-const LikeDislikeButton = ({ upCount, downCount }: LikeDislikeButtonProps) => {
+const LikeDislikeButton = ({ goodCount, badCount, groupId, pageId }: LikeDislikeButtonProps) => {
+  const [likeCount, setLikeCount] = useState(goodCount);
+  const [dislikeCount, setDislikeCount] = useState(badCount);
+
+  const { mutate: likeMutate } = useMutation({
+    mutationFn: () => pageLikeFn({ groupId, pageId }),
+    onSuccess: (response) => {
+      console.log(response);
+      setLikeCount(response.data.response.goodCount);
+    },
+  });
+
+  const { mutate: dislikeMutate } = useMutation({
+    mutationFn: () => pageHateFn({ groupId, pageId }),
+    onSuccess: (response) => {
+      setDislikeCount(response.data.response.badCount);
+    },
+  });
+
+  const handleLikeClick = () => {
+    likeMutate();
+  };
+
+  const handleDislikeClick = () => {
+    dislikeMutate();
+  };
+
+  useEffect(() => {
+    setLikeCount(goodCount);
+    setDislikeCount(badCount);
+  }, [goodCount, badCount]);
+
   return (
     <div className='flex gap-2 h-7'>
-      <Button size='sm' className='rounded-full py-0 flex items-center gap-1'>
+      <Button size='sm' className='rounded-full py-0 flex items-center gap-1' onClick={handleLikeClick}>
         <MdThumbUp />
-        {upCount}
+        {likeCount}
       </Button>
-      <Button color='white' size='sm' className='rounded-full py-0 flex items-center gap-1 border'>
+      <Button
+        color='white'
+        size='sm'
+        className='rounded-full py-0 flex items-center gap-1 border'
+        onClick={handleDislikeClick}
+      >
         <MdThumbDown />
-        {downCount}
+        {dislikeCount}
       </Button>
     </div>
   );

--- a/src/components/Page/Common/LikeDislikeButton.tsx
+++ b/src/components/Page/Common/LikeDislikeButton.tsx
@@ -10,7 +10,7 @@ import PAGE_KEYS from '@constants/queryKeys';
 interface LikeDislikeButtonProps {
   goodCount: number;
   badCount: number;
-  groupId: string;
+  groupId: number;
   pageId: number;
   page: string;
 }

--- a/src/components/Page/Common/RecentChangeList.tsx
+++ b/src/components/Page/Common/RecentChangeList.tsx
@@ -1,19 +1,41 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import { v4 as uuidv4 } from 'uuid';
-import { recentChangePageDummyData } from '@dummy/page';
+import { Link, useParams } from 'react-router-dom';
+import { getRecentChangeListFn } from '@apis/pageApi';
+import { useQuery } from '@tanstack/react-query';
+
+interface RecentChangePage {
+  pageName: string;
+}
 
 const RecentChangeList = () => {
+  const { groupId } = useParams();
+
+  if (!groupId) return null;
+
+  const { data } = useQuery({
+    queryKey: ['recentChangePage', { groupId }],
+    queryFn: () => getRecentChangeListFn({ groupId }),
+  });
+
+  const { recentPage } = data?.data?.response || { recentPage: [] };
+
   return (
-    <div className='w-full'>
-      <h2 className='font-bold px-1 py-2 text-sm'>최근 변경된 페이지</h2>
-      <ul className='p-4 bg-gray-100 text-xs'>
-        {recentChangePageDummyData.map((page) => (
-          <li key={uuidv4()} className='my-2 leading-tight'>
-            {page.pageName}
-          </li>
-        ))}
-      </ul>
-    </div>
+    <Suspense fallback={<div>Loading...</div>}>
+      <div className='w-full'>
+        <h2 className='font-bold px-1 py-2 text-sm'>최근 변경된 페이지</h2>
+        <ul className='p-4 bg-gray-100 text-xs'>
+          {recentPage &&
+            recentPage.map((page: RecentChangePage) => (
+              <li key={uuidv4()} className='my-2 leading-tight'>
+                <Link to={`/${groupId}/${page.pageName}`} className='hover:underline'>
+                  {page.pageName}
+                </Link>
+              </li>
+            ))}
+        </ul>
+      </div>
+    </Suspense>
   );
 };
 

--- a/src/components/Page/Common/RecentChangeList.tsx
+++ b/src/components/Page/Common/RecentChangeList.tsx
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { Link, useParams } from 'react-router-dom';
 import { getRecentChangeListFn } from '@apis/pageApi';
 import { useQuery } from '@tanstack/react-query';
+import PAGE_KEYS from '@constants/queryKeys';
 
 interface RecentChangePage {
   pageName: string;
@@ -14,7 +15,7 @@ const RecentChangeList = () => {
   if (!groupId) return null;
 
   const { data } = useQuery({
-    queryKey: ['recentChangePage', { groupId }],
+    queryKey: PAGE_KEYS.recentChangeList({ groupId }),
     queryFn: () => getRecentChangeListFn({ groupId }),
   });
 

--- a/src/components/Page/Common/RecentChangeList.tsx
+++ b/src/components/Page/Common/RecentChangeList.tsx
@@ -11,12 +11,13 @@ interface RecentChangePage {
 
 const RecentChangeList = () => {
   const { groupId } = useParams();
+  const numGroupId = Number(groupId);
 
   if (!groupId) return null;
 
   const { data } = useQuery({
-    queryKey: PAGE_KEYS.recentChangeList({ groupId }),
-    queryFn: () => getRecentChangeListFn({ groupId }),
+    queryKey: PAGE_KEYS.recentChangeList({ groupId: numGroupId }),
+    queryFn: () => getRecentChangeListFn({ groupId: numGroupId }),
   });
 
   const { recentPage } = data?.data?.response || { recentPage: [] };

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -1,0 +1,6 @@
+const PAGE_KEYS = {
+  byTitle: ({ groupId, title }: { groupId: string; title: string }) => ['pageByTitle', { groupId, title }] as const,
+  recentChangeList: ({ groupId }: { groupId: string }) => ['recentChangeList', { groupId }] as const,
+};
+
+export default PAGE_KEYS;

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -1,6 +1,6 @@
 const PAGE_KEYS = {
-  byTitle: ({ groupId, title }: { groupId: string; title: string }) => ['pageByTitle', { groupId, title }] as const,
-  recentChangeList: ({ groupId }: { groupId: string }) => ['recentChangeList', { groupId }] as const,
+  byTitle: ({ groupId, title }: { groupId: number; title: string }) => ['pageByTitle', { groupId, title }] as const,
+  recentChangeList: ({ groupId }: { groupId: number }) => ['recentChangeList', { groupId }] as const,
 };
 
 export default PAGE_KEYS;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,6 +19,8 @@ import PostEditPage from '@pages/PostEditPage';
 import PostHistoryPage from '@pages/PostHistoryPage';
 import GroupJoinPage from '@pages/GroupJoinPage';
 
+import NotFoundPage from '@pages/NotFoundPage';
+
 import MainLayout from '@components/Layout/MainLayout';
 import PageLayout from '@components/Layout/PageLayout';
 import App from './App';
@@ -78,6 +80,10 @@ const router = createBrowserRouter([
           {
             path: '/:groupName/:page/:postId/history',
             element: <PostHistoryPage />,
+          },
+          {
+            path: '/404',
+            element: <NotFoundPage />,
           },
         ],
       },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -85,11 +85,11 @@ const router = createBrowserRouter([
         element: <PageLayout />,
         children: [
           {
-            path: '/:groupName/:page?',
+            path: '/:groupId/:page',
             element: <GroupMainPage />,
           },
           {
-            path: '/:groupName/:page?/:post/edit',
+            path: '/:groupId/:page/:post/edit',
             element: <PostEditPage />,
           },
         ],

--- a/src/pages/GroupMainPage.tsx
+++ b/src/pages/GroupMainPage.tsx
@@ -10,6 +10,7 @@ import LikeDislikeButton from '@components/Page/Common/LikeDislikeButton';
 import AddPostButton from '@components/Page/Post/AddPostButton';
 import { useQuery } from '@tanstack/react-query';
 import { getPageByTitleFn } from '@apis/pageApi';
+import PAGE_KEYS from '@constants/queryKeys';
 
 interface Post {
   postId: number;
@@ -38,7 +39,7 @@ const GroupMainPage = () => {
   if (!page) return null;
 
   const { data, error, status } = useQuery({
-    queryKey: ['page', { groupId, title: page }],
+    queryKey: PAGE_KEYS.byTitle({ groupId, title: page }),
     queryFn: () => getPageByTitleFn({ groupId, title: page }),
   });
 

--- a/src/pages/GroupMainPage.tsx
+++ b/src/pages/GroupMainPage.tsx
@@ -46,6 +46,8 @@ const GroupMainPage = () => {
     pageName: 'test',
     pageId: 1,
     postList: [],
+    goodCount: 0,
+    badCount: 0,
   };
 
   const handleWriteClick = () => {

--- a/src/pages/GroupMainPage.tsx
+++ b/src/pages/GroupMainPage.tsx
@@ -8,8 +8,8 @@ import Post from '@components/Page/Post/Post';
 import { Button } from '@material-tailwind/react';
 import LikeDislikeButton from '@components/Page/Common/LikeDislikeButton';
 import AddPostButton from '@components/Page/Post/AddPostButton';
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { createPageFn, getPageByTitleFn } from '@apis/pageApi';
+import { useQuery } from '@tanstack/react-query';
+import { getPageByTitleFn } from '@apis/pageApi';
 
 interface Post {
   postId: number;
@@ -44,8 +44,6 @@ const GroupMainPage = () => {
 
   const { pageName, pageId, postList } = data?.data?.response || { pageName: 'test', pageId: 1, postList: [] };
 
-  const { mutate } = useMutation({ mutationFn: createPageFn });
-
   const handleWriteClick = () => {
     navigate('개요/edit', {
       state: { pageId, index: '1.', pageName, postTitle: '개요', content: '' },
@@ -54,8 +52,7 @@ const GroupMainPage = () => {
 
   useEffect(() => {
     if (error && (error as Error).response.data.error.message === '존재하지 않는 페이지 입니다.') {
-      mutate({ groupId, pageName: page });
-      navigate(`/${groupId}/${page}`, { replace: true });
+      navigate('/404', { replace: true });
     }
   }, [data, error, status]);
 

--- a/src/pages/GroupMainPage.tsx
+++ b/src/pages/GroupMainPage.tsx
@@ -34,13 +34,14 @@ interface Error {
 const GroupMainPage = () => {
   const navigate = useNavigate();
   const { groupId, page } = useParams();
+  const numGroupId = Number(groupId);
 
   if (!groupId) return null;
   if (!page) return null;
 
   const { data, error, status } = useQuery({
-    queryKey: PAGE_KEYS.byTitle({ groupId, title: page }),
-    queryFn: () => getPageByTitleFn({ groupId, title: page }),
+    queryKey: PAGE_KEYS.byTitle({ groupId: numGroupId, title: page }),
+    queryFn: () => getPageByTitleFn({ groupId: numGroupId, title: page }),
   });
 
   const { pageName, pageId, postList, goodCount, badCount } = data?.data?.response || {
@@ -73,7 +74,7 @@ const GroupMainPage = () => {
             <LikeDislikeButton
               goodCount={goodCount}
               badCount={badCount}
-              groupId={groupId}
+              groupId={numGroupId}
               pageId={pageId}
               page={page}
             />

--- a/src/pages/GroupMainPage.tsx
+++ b/src/pages/GroupMainPage.tsx
@@ -57,6 +57,7 @@ const GroupMainPage = () => {
   };
 
   useEffect(() => {
+    if (error) console.log(error);
     if (error && (error as Error).response.data.error.message === '존재하지 않는 페이지 입니다.') {
       navigate('/404', { replace: true });
     }
@@ -68,7 +69,13 @@ const GroupMainPage = () => {
         <PageTitleSection
           title={pageName}
           aboveAdornment={
-            <LikeDislikeButton goodCount={goodCount} badCount={badCount} groupId={groupId} pageId={pageId} />
+            <LikeDislikeButton
+              goodCount={goodCount}
+              badCount={badCount}
+              groupId={groupId}
+              pageId={pageId}
+              page={page}
+            />
           }
         />
         <PageContainer pageId={postList.length !== 0 ? pageId : undefined} hasRecentChangeList>

--- a/src/pages/GroupMainPage.tsx
+++ b/src/pages/GroupMainPage.tsx
@@ -42,7 +42,11 @@ const GroupMainPage = () => {
     queryFn: () => getPageByTitleFn({ groupId, title: page }),
   });
 
-  const { pageName, pageId, postList } = data?.data?.response || { pageName: 'test', pageId: 1, postList: [] };
+  const { pageName, pageId, postList, goodCount, badCount } = data?.data?.response || {
+    pageName: 'test',
+    pageId: 1,
+    postList: [],
+  };
 
   const handleWriteClick = () => {
     navigate('개요/edit', {
@@ -59,7 +63,12 @@ const GroupMainPage = () => {
   return (
     <Suspense fallback={<div>Loading...</div>}>
       <div className='mx-auto 2xl:max-w-screen-xl xl:max-w-screen-lg'>
-        <PageTitleSection title={pageName} aboveAdornment={<LikeDislikeButton upCount={12} downCount={7} />} />
+        <PageTitleSection
+          title={pageName}
+          aboveAdornment={
+            <LikeDislikeButton goodCount={goodCount} badCount={badCount} groupId={groupId} pageId={pageId} />
+          }
+        />
         <PageContainer pageId={postList.length !== 0 ? pageId : undefined} hasRecentChangeList>
           {postList.length !== 0 ? (
             <ul>

--- a/src/pages/GroupMainPage.tsx
+++ b/src/pages/GroupMainPage.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { MdArrowCircleRight } from 'react-icons/md';
 import { v4 as uuidv4 } from 'uuid';
-import { getPageInfo } from '@dummy/page';
 // import { getEmptyPageInfo } from '@dummy/page';
 import PageTitleSection from '@components/Page/Common/PageTitleSection';
 import PageContainer from '@components/Page/Common/PageContainer';
@@ -10,14 +9,31 @@ import Post from '@components/Page/Post/Post';
 import { Button } from '@material-tailwind/react';
 import LikeDislikeButton from '@components/Page/Common/LikeDislikeButton';
 import AddPostButton from '@components/Page/Post/AddPostButton';
+import { useQuery } from '@tanstack/react-query';
+import getPageByTitleFn from '@apis/pageApi';
+
+interface Post {
+  postId: number;
+  index: string;
+  postTitle: string;
+  content: string;
+  order: number;
+  parentPostId: number;
+}
 
 const GroupMainPage = () => {
   const navigate = useNavigate();
-  const { groupName, page } = useParams();
+  const { groupId, page } = useParams();
 
-  if (!groupName) return null;
+  if (!groupId) return null;
+  if (!page) return null;
 
-  const { pageName, pageId, postList } = getPageInfo(page ?? groupName);
+  const { data, status } = useQuery({
+    queryKey: ['page', `${groupId}_${page}`],
+    queryFn: () => getPageByTitleFn({ groupId, title: page }),
+  });
+
+  const { pageName, pageId, postList } = data ?? { pageName: '', pageId: 0, postList: [] };
   // const { pageName, pageId, postList } = getEmptyPageInfo(page ?? groupName);
 
   const handleWriteClick = () => {
@@ -26,43 +42,55 @@ const GroupMainPage = () => {
     });
   };
 
+  let errorComponent = null;
+  if (status === 'error') {
+    errorComponent = <p>에러입니당!!</p>;
+  }
+
+  // useEffect(() => {
+  //   // Any other side effects can go here
+  // }, [status]);
+
   return (
-    <div className='mx-auto 2xl:max-w-screen-xl xl:max-w-screen-lg'>
-      <PageTitleSection title={pageName} aboveAdornment={<LikeDislikeButton upCount={12} downCount={7} />} />
-      <PageContainer pageId={postList.length !== 0 ? pageId : undefined} hasRecentChangeList>
-        {postList.length !== 0 ? (
-          <ul>
-            {postList.map((post) => (
-              <li key={uuidv4()}>
-                <Post
-                  pageId={pageId}
-                  pageName={pageName}
-                  index={post.index}
-                  postTitle={post.postTitle}
-                  content={post.content}
-                />
-                <AddPostButton />
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <article className='flex justify-between items-center p-4 bg-gray-100 rounded-lg px-4'>
-            <p className='text-sm shrink-0'>
-              <span className='font-bold'>{`"${page ?? groupName}"`}</span>에 새로운 글을 작성해보세요!
-            </p>
-            <Button
-              variant='text'
-              ripple={false}
-              className='group flex items-center gap-1 py-1 px-2 text-sm font-bold hover:bg-transparent active:bg-transparent shrink-0'
-              onClick={handleWriteClick}
-            >
-              <span>글쓰기</span>
-              <MdArrowCircleRight className='w-5 h-5 group-hover:animate-arrowBounce' />
-            </Button>
-          </article>
-        )}
-      </PageContainer>
-    </div>
+    <Suspense fallback={<div>Loading...</div>}>
+      <div className='mx-auto 2xl:max-w-screen-xl xl:max-w-screen-lg'>
+        <PageTitleSection title={pageName} aboveAdornment={<LikeDislikeButton upCount={12} downCount={7} />} />
+        <PageContainer pageId={postList.length !== 0 ? pageId : undefined} hasRecentChangeList>
+          {errorComponent}
+          {postList.length !== 0 ? (
+            <ul>
+              {postList.map((post: Post) => (
+                <li key={uuidv4()}>
+                  <Post
+                    pageId={pageId}
+                    pageName={pageName}
+                    index={post.index}
+                    postTitle={post.postTitle}
+                    content={post.content}
+                  />
+                  <AddPostButton />
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <article className='flex justify-between items-center p-4 bg-gray-100 rounded-lg px-4'>
+              <p className='text-sm shrink-0'>
+                <span className='font-bold'>{`"${page}"`}</span>에 새로운 글을 작성해보세요!
+              </p>
+              <Button
+                variant='text'
+                ripple={false}
+                className='group flex items-center gap-1 py-1 px-2 text-sm font-bold hover:bg-transparent active:bg-transparent shrink-0'
+                onClick={handleWriteClick}
+              >
+                <span>글쓰기</span>
+                <MdArrowCircleRight className='w-5 h-5 group-hover:animate-arrowBounce' />
+              </Button>
+            </article>
+          )}
+        </PageContainer>
+      </div>
+    </Suspense>
   );
 };
 

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -1,0 +1,22 @@
+import { Button } from '@material-tailwind/react';
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+/**
+ * 404 Not Found 페이지
+ */
+const NotFoundPage = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className='text-center p-40'>
+      <h1 className='text-2xl font-extrabold'>404 NOT FOUND</h1>
+      <p>페이지를 찾을 수 없습니다.</p>
+      <Button className='mt-5' onClick={() => navigate(-1)}>
+        뒤로가기
+      </Button>
+    </div>
+  );
+};
+
+export default NotFoundPage;


### PR DESCRIPTION
## ⭐Key Changes
> 핵심 변경 사항에 대해서 적어주세요.

![image](https://github.com/Step3-kakao-tech-campus/Team8_FE/assets/48706964/794aca92-db42-4a9d-993c-e497c505fae7)

글쓰기를 제외하고, 위 화면에 보이는 모든 기능을 제작하였습니다.

1. 그룹 내 페이지 조회
- /groupId/page(name)으로 이동했을 때, 페이지 이름으로 해당 페이지를 조회합니다.
- 없는 페이지를 호출하면 404 페이지로 이동합니다.
- 메인 페이지에서 에러가 나지 않으려면 그룹 생성 완료 시 메인 페이지를 자동으로 만들어줘야 합니다.
2. 최근 변경된 페이지
- 마구마구 페이지 생성을 해서 확인한 결과 제대로 동작합니다.
- 페이지 이름 위에 커서를 올리면 밑줄이 생깁니다.
3. 좋아요 싫어요 버튼
- 초기 카운트는 페이지 조회 API에서 같이 받아옵니다.
- 버튼을 누르면 버튼 컴포넌트 내의 mutate 함수가 실행되어 갱신된 카운트를 표시합니다.
- 초기 렌더링 시 카운트값이 props로 넘어오면 바로 보여줄 수 있도록 useEffect를 사용하였습니다.

<br>

## 📌Issue
- Close #114 

<br>

## 👪To Reviewers

모든 페이지에 로그인이 필요합니다!! 기능을 확인하려면 아래의 테스트 아이디로 로그인 한 후 토큰을 받아와 instance에 추가하는 작업이 필요합니다.

```
{
    "email": "test1@test.com",
    "password": "aaaassss1"
}
```

```
// 토큰 추가
const token ='[받아온 토큰 값]';
instance.defaults.headers.common.Authorization = `Bearer ${token}`;
```

위 작업 후 메인 페이지에서 group3을 선택해 확인해보세요. group3만 그룹 생성 및 메인 페이지 생성 해두었습니다. 나머진 직접 생성하셔야 해요.

로그인 후 토큰을 저장하고 불러와 미리 붙여놓는 작업이 끝나기 전까지는 위와 같은 방법으로 확인하셔야 될 것 같습니다. ㅠㅠ
postman을 이용하면 토큰을 편하게 받아오실 수 있습니다.

+ 에러 처리를 추후에 하기로 해서 메인 페이지 컴포넌트의 에러 처리가 요상할 수 있습니다! 양해바랍니다!
+ 이제 메인 페이지와 나머지 일반 페이지들을 구분할 필요가 없어져서 나중에 컴포넌트 이름 바꾸는게 나을 수도?!

<br>

## 🐾Next Move
> 다음 개발 목표를 적어주세요

포스트 생성을 한번 해보려고 합니다.. ㅎㅎ...