### PR TITLE
페이지 검색 및 생성

### DIFF
--- a/src/apis/pageApi.ts
+++ b/src/apis/pageApi.ts
@@ -2,10 +2,6 @@ import { instance } from './axios';
 
 // /group/${groupId}/page 관련 api
 
-const token =
-  'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyIiwiYXV0aCI6InVzZXIiLCJleHAiOjE2OTg3NzMxMzl9.mf9x6yoqdwgL8nRl7qjdekaP0MScAqIfEztgLkkbnnk';
-instance.defaults.headers.common.Authorization = `Bearer ${token}`;
-
 export const getPageByTitleFn = ({ groupId, title }: { groupId: number; title: string }) =>
   instance.get(`/group/${groupId}/page?title=${title}`);
 
@@ -20,3 +16,6 @@ export const pageLikeFn = ({ groupId, pageId }: { groupId: number; pageId: numbe
 
 export const pageHateFn = ({ groupId, pageId }: { groupId: number; pageId: number }) =>
   instance.post(`/group/${groupId}/page/${pageId}/hate`);
+
+export const searchPageFn = ({ groupId, keyword }: { groupId: number; keyword: string }) =>
+  instance.get(`/group/${groupId}/page/search?keyword=${keyword}&page=1`);

--- a/src/components/Common/SearchInput.tsx
+++ b/src/components/Common/SearchInput.tsx
@@ -9,7 +9,7 @@ interface InputProps {
 }
 
 const SearchInput = ({ isLoggedIn, className }: InputProps) => {
-  const { groupName } = useParams();
+  const { groupId } = useParams();
   const [searchBar, setSearchBar] = useState<string>('');
   const navigate = useNavigate();
 
@@ -22,7 +22,7 @@ const SearchInput = ({ isLoggedIn, className }: InputProps) => {
   };
   const handleSubmit = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && searchBar && e.nativeEvent.isComposing === false) {
-      navigate(groupName ? `${groupName}/search?keyword=${searchBar}` : `/search/group?keyword=${searchBar}`);
+      navigate(groupId ? `${groupId}/search?keyword=${searchBar}` : `/search/group?keyword=${searchBar}`);
       setSearchBar('');
     }
   };
@@ -35,7 +35,7 @@ const SearchInput = ({ isLoggedIn, className }: InputProps) => {
           className={`w-full px-9 !text-base !bg-gray-100 !border-none focus:!bg-white focus:shadow-md ${
             searchBar ? 'rounded-b-none' : ''
           }`}
-          placeholder={groupName ? '페이지를 검색해보세요.' : '그룹을 검색해보세요.'}
+          placeholder={groupId ? '페이지를 검색해보세요.' : '그룹을 검색해보세요.'}
           value={searchBar}
           crossOrigin=''
           labelProps={{

--- a/src/components/Header/HeaderMenu.tsx
+++ b/src/components/Header/HeaderMenu.tsx
@@ -10,7 +10,7 @@ import GroupMemberListModal from '@components/Modal/GroupMemberListModal';
 import InviteModal from '../Modal/InviteModal';
 
 const HeaderMenu = () => {
-  const { groupName } = useParams();
+  const { groupId } = useParams();
   const navigate = useNavigate();
   const setIsLoggedIn = useSetRecoilState(isLoggedInState);
 
@@ -21,8 +21,8 @@ const HeaderMenu = () => {
     setIsLoggedIn(false);
   };
   const handleMyPageClick = () => {
-    if (groupName) {
-      navigate(`/${groupName}/myPage`);
+    if (groupId) {
+      navigate(`/${groupId}/myPage`);
     } else {
       navigate('/myPage');
     }
@@ -37,9 +37,9 @@ const HeaderMenu = () => {
           </Button>
         </MenuHandler>
         <MenuList>
-          <MenuItem onClick={handleMyPageClick}>{groupName ? '그룹 마이페이지' : '마이페이지'}</MenuItem>
-          {groupName && <MenuItem onClick={inviteModal.handleModal}>그룹원 초대</MenuItem>}
-          {groupName && <MenuItem onClick={groupMemberListModal.handleModal}>그룹원 목록</MenuItem>}
+          <MenuItem onClick={handleMyPageClick}>{groupId ? '그룹 마이페이지' : '마이페이지'}</MenuItem>
+          {groupId && <MenuItem onClick={inviteModal.handleModal}>그룹원 초대</MenuItem>}
+          {groupId && <MenuItem onClick={groupMemberListModal.handleModal}>그룹원 목록</MenuItem>}
           <MenuItem onClick={handleLogout}>로그아웃</MenuItem>
         </MenuList>
       </Menu>

--- a/src/components/Modal/PageCreateModal.tsx
+++ b/src/components/Modal/PageCreateModal.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Button, Card, CardBody, CardFooter, Dialog } from '@material-tailwind/react';
+
+interface PageCreateModalProps {
+  page?: string;
+  isOpen: boolean;
+  onClick: () => void;
+  handleModal: () => void;
+}
+
+const PageCreateModal = ({ page, isOpen, onClick, handleModal }: PageCreateModalProps) => {
+  return (
+    <Dialog open={isOpen} handler={onClick} size='xs' className='bg-transparent shadow-none'>
+      <Card className='mx-auto w-full max-w-[24rem]'>
+        <CardBody className='flex flex-col gap-4 text-black text-center'>
+          <p>
+            <span className='font-bold'>{page}</span> 페이지를 생성합니다.
+          </p>
+        </CardBody>
+        <CardFooter className='pt-0 text-right'>
+          <Button
+            variant='outlined'
+            ripple={false}
+            size='sm'
+            onClick={onClick}
+            className='mr-1 bg-black text-white rounded'
+          >
+            확인
+          </Button>
+          <Button variant='outlined' size='sm' ripple={false} onClick={handleModal} className='rounded'>
+            취소
+          </Button>
+        </CardFooter>
+      </Card>
+    </Dialog>
+  );
+};
+
+export default PageCreateModal;

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -1,6 +1,8 @@
 const PAGE_KEYS = {
   byTitle: ({ groupId, title }: { groupId: number; title: string }) => ['pageByTitle', { groupId, title }] as const,
   recentChangeList: ({ groupId }: { groupId: number }) => ['recentChangeList', { groupId }] as const,
+  searchKeyword: ({ groupId, keyword }: { groupId: number; keyword: string }) =>
+    ['searchKeyword', { groupId, keyword }] as const,
 };
 
 export default PAGE_KEYS;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -75,7 +75,7 @@ const router = createBrowserRouter([
             element: <MyContributePage />,
           },
           {
-            path: '/:groupName/search',
+            path: '/:groupId/search',
             element: <SearchResultPage />,
           },
           {


### PR DESCRIPTION
## ⭐Key Changes
> 핵심 변경 사항에 대해서 적어주세요.
1. 그룹 내에서 키워드로 페이지 검색하는 기능 구현
2. 검색과 완전히 일치하는 페이지가 있는 경우 그 페이지로 바로 이동
3. 일치하는 페이지가 없으면 검색 결과 제공
4. 새 페이지 생성 누르면 생성할거냐는 모달이 뜨고 확인 누를 시 페이지 생성 후 그 페이지로 이동

![image](https://github.com/Step3-kakao-tech-campus/Team8_FE/assets/48706964/28d1918d-7c5c-4c0b-8953-257cdd94f768)

![image](https://github.com/Step3-kakao-tech-campus/Team8_FE/assets/48706964/baa7614c-1f9a-499c-b15a-5ee7668f72ec)


<br>

## 📌Issue
- Close #114 

<br>

## 👪To Reviewers
> reviewer에게 하고 싶은 말을 적어주세요.

지금 최근 변경에 있는 페이지들 만들어놔서 뜨는 건데요
'페이지' 라고 검색하면 첫번째 페이지, 두번째 페이지, 세번째 페이지 다 안 뜹니다.
'세번째' 라고 검색하면 세번째 페이지가 뜹니다.

이상해서 물어봤는데 백엔드에서.. 그걸로 시작하는 것만 검색되게 해놨다고 (ㅋㅋ ㅠㅠ)
포함되는거 다 검색되도록 변경해달라고 요청했어요! 그래서 백에서 고치고 재배포하면 검색 결과 잘 나올거예요.

페이지 검색 결과에 content는 제일 위 post에서 받아오는거라 포스트를 안 만들면 안 뜹니다!
그래서 세번째 페이지에 post 하나 임의로 생성해서 테스트 해봤어요.

+ useQuery에 useEffect 안 쓰고 싶었는데, 최근에 onSuccess랑 onError를 쓰지말라고 삭제했더군요. 쓰면 기능은 되지만 사이드 이펙트가 심해서 권장하지 않는다고 합니다.
권장하는 방법은 쿼리 클라이언트에서 전역으로 에러처리를 하는건데, 해당 컴포넌트 같은 경우엔 전역으로 처리할만한 에러가 아니고 특수한 경우여서 useEffect 걸어서 해결했습니다~

<br>

## 🐾Next Move
> 다음 개발 목표를 적어주세요

- 포스트를 만들어야겠지