### PR TITLE
Feature/메인페이지 api 연결

### DIFF
--- a/src/apis/dto.ts
+++ b/src/apis/dto.ts
@@ -1,0 +1,11 @@
+export interface Group {
+  groupId: number;
+  groupImage: string;
+  groupName: string;
+}
+
+export interface MainGroups {
+  myGroup: Group[];
+  officialGroup: Group[];
+  unOfficialGroup: Group[];
+}

--- a/src/apis/mainApi.ts
+++ b/src/apis/mainApi.ts
@@ -1,0 +1,4 @@
+import { instance } from './axios';
+
+// eslint-disable-next-line import/prefer-default-export
+export const getGroupListFn = () => instance.get(`/main`).then(({ data }) => data.response);

--- a/src/assets/images/logo/logo.svg
+++ b/src/assets/images/logo/logo.svg
@@ -1,4 +1,4 @@
-<svg width="current" height="current" viewBox="0 0 51 50" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="current" height="current" viewBox="0 0 51 50" fill="black" xmlns="http://www.w3.org/2000/svg">
 <rect x="0.5" width="50" height="50" rx="8" fill="current"/>
 <path d="M39.2909 13.15L33.3209 34.78H30.3509L25.5509 17.11L20.6609 34.78H17.6309L11.7209 13.15H14.8409L19.2809 30.82L24.1109 13.15H26.9909L31.8209 30.82L36.3209 13.15H39.2909Z" fill="white"/>
 </svg>

--- a/src/components/Home/GroupCard.tsx
+++ b/src/components/Home/GroupCard.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Card, CardHeader, CardBody } from '@material-tailwind/react';
 import { Link } from 'react-router-dom';
+import Logo from '@assets/images/logo/logo.svg';
 
 interface GroupCardProps {
   group: {
@@ -11,6 +12,13 @@ interface GroupCardProps {
 }
 
 const GroupCard = ({ group }: GroupCardProps) => {
+  const [isImgError, setImageError] = useState(false);
+
+  const handleImgError: React.ReactEventHandler<HTMLImageElement> = (e) => {
+    e.currentTarget.src = Logo;
+    setImageError(true);
+  };
+
   return (
     <Link to={`/${group.groupId}/${group.groupName}`}>
       <Card className='mt-6 w-max cursor-pointer mx-auto' shadow={false}>
@@ -18,7 +26,8 @@ const GroupCard = ({ group }: GroupCardProps) => {
           <img
             src={group.groupImage}
             alt={`${group.groupName}`}
-            className='object-cover w-36 h-36 hover:scale-110 duration-300'
+            onError={handleImgError}
+            className={`object-cover w-36 h-36 hover:scale-110 duration-300  ${isImgError ? 'opacity-10 p-10' : ''}`}
           />
         </CardHeader>
         <CardBody className='text-center pt-4 pb-1 px-1 text-black text-sm'>

--- a/src/components/Home/GroupList.tsx
+++ b/src/components/Home/GroupList.tsx
@@ -1,12 +1,7 @@
 import React from 'react';
 import { v4 as uuidv4 } from 'uuid';
+import { Group } from '@apis/dto';
 import GroupCard from './GroupCard';
-
-interface Group {
-  groupId: number;
-  groupImage: string;
-  groupName: string;
-}
 
 const GroupList = ({ groups }: { groups: Group[] }) => {
   return (

--- a/src/components/Home/OfficialGroup.tsx
+++ b/src/components/Home/OfficialGroup.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { Carousel } from '@material-tailwind/react';
 import { Link } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
-import { officialGroupDummyData } from '@dummy/group';
+import { Group } from '@apis/dto';
 
-const OfficialGroup = () => {
+const OfficialGroup = ({ officialGroups }: { officialGroups: Group[] }) => {
   return (
     <Carousel className='rounded-xl max-w-[768px]' loop>
-      {officialGroupDummyData.map((group) => (
+      {officialGroups.map((group) => (
         <Link to={`/${group.groupName}`} key={uuidv4()}>
           <div key={group.groupId} className='relative h-full w-full'>
             <img src={group.groupImage} alt={group.groupName} className='w-full h-40 object-cover mx-auto' />

--- a/src/components/Page/Common/LikeDislikeButton.tsx
+++ b/src/components/Page/Common/LikeDislikeButton.tsx
@@ -5,7 +5,7 @@ import { MdThumbDown, MdThumbUp } from 'react-icons/md';
 import { useMutation } from '@tanstack/react-query';
 import { pageHateFn, pageLikeFn } from '@apis/pageApi';
 import { queryClient } from '@apis/queryClient';
-import PAGE_KEYS from '@constants/queryKeys';
+import { PAGE_KEYS } from '@constants/queryKeys';
 
 interface LikeDislikeButtonProps {
   goodCount: number;

--- a/src/components/Page/Common/RecentChangeList.tsx
+++ b/src/components/Page/Common/RecentChangeList.tsx
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { Link, useParams } from 'react-router-dom';
 import { getRecentChangeListFn } from '@apis/pageApi';
 import { useQuery } from '@tanstack/react-query';
-import PAGE_KEYS from '@constants/queryKeys';
+import { PAGE_KEYS } from '@constants/queryKeys';
 
 interface RecentChangePage {
   pageName: string;

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -5,4 +5,8 @@ const PAGE_KEYS = {
     ['searchKeyword', { groupId, keyword }] as const,
 };
 
-export default PAGE_KEYS;
+const MAIN_KEYS = {
+  main: ['main'],
+};
+
+export { PAGE_KEYS, MAIN_KEYS };

--- a/src/pages/GroupMainPage.tsx
+++ b/src/pages/GroupMainPage.tsx
@@ -10,7 +10,7 @@ import LikeDislikeButton from '@components/Page/Common/LikeDislikeButton';
 import AddPostButton from '@components/Page/Post/AddPostButton';
 import { useQuery } from '@tanstack/react-query';
 import { getPageByTitleFn } from '@apis/pageApi';
-import PAGE_KEYS from '@constants/queryKeys';
+import { PAGE_KEYS } from '@constants/queryKeys';
 
 interface Post {
   postId: number;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -41,7 +41,7 @@ const HomePage = () => {
                 그룹 생성
               </Button>
             </div>
-            {groupList && groupList.myGroup.length > 0 ? (
+            {groupList && groupList.myGroup && groupList.myGroup.length > 0 ? (
               <GroupList groups={groupList.myGroup} />
             ) : (
               <p className='text-center my-10'>참여한 그룹이 없습니다.</p>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -3,18 +3,22 @@ import { Button } from '@material-tailwind/react';
 import { ReactComponent as TextLogo } from '@assets/images/logo/textLogo.svg';
 import OfficialGroup from '@components/Home/OfficialGroup';
 import GroupList from '@components/Home/GroupList';
-import { unOfficialGroupDummyData } from '@dummy/group';
 import { ReactComponent as Logo } from '@assets/images/logo/logo.svg';
 import SearchInput from '@components/Common/SearchInput';
 import { useRecoilValue } from 'recoil';
 import isLoggedInState from '@recoil/atoms/auth';
 import { useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { MAIN_KEYS } from '@constants/queryKeys';
+import { getGroupListFn } from '@apis/mainApi';
+import { MainGroups } from '@apis/dto';
 
 const titleStyle = 'font-bold text-lg mb-4 mt-20';
 
 const HomePage = () => {
   const isLoggedIn = useRecoilValue(isLoggedInState);
   const navigate = useNavigate();
+  const { data: groupList } = useQuery<MainGroups>({ queryKey: MAIN_KEYS.main, queryFn: getGroupListFn });
 
   return (
     <main>
@@ -37,17 +41,29 @@ const HomePage = () => {
                 그룹 생성
               </Button>
             </div>
-            <GroupList groups={unOfficialGroupDummyData} />
+            {groupList && groupList.myGroup.length > 0 ? (
+              <GroupList groups={groupList.myGroup} />
+            ) : (
+              <p className='text-center my-10'>참여한 그룹이 없습니다.</p>
+            )}
           </section>
           <section>
             <h2 className={titleStyle}>공식 그룹</h2>
-            <OfficialGroup />
+            {groupList && groupList.officialGroup.length > 0 ? (
+              <OfficialGroup officialGroups={groupList.officialGroup} />
+            ) : (
+              <p className='text-center my-10'>등록된 공식 그룹이 없습니다.</p>
+            )}
           </section>
         </div>
       )}
       <section>
         <h2 className={titleStyle}>그룹 살펴보기</h2>
-        <GroupList groups={unOfficialGroupDummyData} />
+        {groupList && groupList.unOfficialGroup.length > 0 ? (
+          <GroupList groups={groupList.unOfficialGroup} />
+        ) : (
+          <p className='text-center my-10'>등록된 그룹이 없습니다.</p>
+        )}
       </section>
     </main>
   );

--- a/src/pages/SearchResultPage.tsx
+++ b/src/pages/SearchResultPage.tsx
@@ -6,7 +6,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { Button } from '@material-tailwind/react';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { createPageFn, getPageByTitleFn, searchPageFn } from '@apis/pageApi';
-import PAGE_KEYS from '@constants/queryKeys';
+import { PAGE_KEYS } from '@constants/queryKeys';
 import PageCreateModal from '@components/Modal/PageCreateModal';
 import useModal from '@hooks/useModal';
 


### PR DESCRIPTION
## ⭐Key Changes
- 메인 페이지에 내 그룹, 공식 그룹, 그룹 살펴보기 각각의 그룹들 API 연결하여 띄워줬습니다.
- 그룹 없을 때는 `~그룹이 없습니다.` 형태의 문구를 띄워주도록 하였습니다.
- 이미지 안 불러와질 때 아래 이미지처럼 대체 텍스트로 뜨지 않도록 대체 이미지(로고 반투명하게)로 처리하였습니다.(🖼️Preview 참고)
  <img width="300" alt="image" src="https://github.com/Step3-kakao-tech-campus/Team8_FE/assets/78250089/20c67dbc-212b-4a76-8cf8-a153f7b92821">

## 📌Issue
- Close #125 


## 👪To Reviewers
- @qwer15948 쿼리키 export default 되어 있던 거 여러개 key 전달을 위해 default 제거해서 호출하는 부분에 중괄호 다 추가해주었습니다.
- 그룹 생성해도 내 그룹 추가 안 돼서 백엔드에 문의 드려놓은 상태입니다.
- 로고 `fill` 색상이 지정되어 있지 않아서 따로 색 넣지 않으면 흰색으로 보이길래 주소로 이미지 띄워줄 때 어려움이 있어서 `fill` 색상 `black`으로 지정해두었습니다.
- API에서 응답으로 주는 값들 타입 지정을 위해 `dto.ts` 파일 만들었습니다.


## 🖼️Preview
|로그인 전|로그인 후|
|--------|--------|
|<img width="1728" alt="image" src="https://github.com/Step3-kakao-tech-campus/Team8_FE/assets/78250089/5e9d8548-9782-4515-ad36-72415331c1dd">|<img width="1728" alt="image" src="https://github.com/Step3-kakao-tech-campus/Team8_FE/assets/78250089/c46ee36b-8085-4884-b823-c53a055fdc16">|

로그인 후는 한 번에 캡쳐하려고 화면 축소한 이미지입니다!

## 🐾Next Move
- 로그아웃 api 연결
