### PR TITLE
포스트 생성 및 수정

### DIFF
--- a/src/apis/postApi.ts
+++ b/src/apis/postApi.ts
@@ -1,0 +1,31 @@
+import { instance } from './axios';
+
+// group/groupId/post 관련 api
+
+export const createPostFn = ({
+  groupId,
+  pageId,
+  parentPostId,
+  order,
+  title,
+  content,
+}: {
+  groupId: number;
+  pageId: number;
+  parentPostId: number;
+  order: number;
+  title: string;
+  content: string;
+}) => instance.post(`/group/${groupId}/post/create`, { pageId, parentPostId, order, title, content });
+
+export const modifyPostFn = ({
+  groupId,
+  postId,
+  title,
+  content,
+}: {
+  groupId: number;
+  postId: number;
+  title: string;
+  content: string;
+}) => instance.put(`/group/${groupId}/post/modify`, { postId, title, content });

--- a/src/components/Page/Post/AddPostButton.tsx
+++ b/src/components/Page/Post/AddPostButton.tsx
@@ -2,13 +2,66 @@ import React, { useState } from 'react';
 
 import { MdAddCircleOutline } from 'react-icons/md';
 import { Button, ButtonGroup } from '@material-tailwind/react';
+import { useNavigate } from 'react-router-dom';
 
-const AddPostButton = () => {
+interface Post {
+  postId: number;
+  index: string;
+  postTitle: string;
+  content: string;
+  order: number;
+  parentPostId: number;
+}
+
+interface Props {
+  post: Post;
+  pageId: number;
+  pageName: string;
+  descendantCount: number;
+}
+
+const generateNextIndex = (currentIndex: string) => {
+  const parts = currentIndex.split('.');
+  parts[parts.length - 1] = (parseInt(parts[parts.length - 1], 10) + 1).toString();
+  return parts.join('.');
+};
+
+const AddPostButton = ({ post, pageId, pageName, descendantCount }: Props) => {
   const [isSplit, setIsSplit] = useState(false);
+
+  const { parentPostId, order, index, postTitle, content } = post;
+
+  const navigate = useNavigate();
 
   const handleButtonClick = () => {
     setIsSplit((prev) => !prev);
   };
+
+  // 다음 목차에 추가하는 경우: parentPostId = 현재 포스트의 parentPostId, order = 현재 포스트의 order + 포스트의 후손 수 + 1 지점, index = 현재 포스트 index의 가장 끝만 + 1
+  // 1(부모: 1)에서 누르면 2가 되고, 1.1에서 누르면 1.2가 되고, 1.1.3에서 누르면 1.1.4가 됨
+  const handleAddNextPostClick = () => {
+    const newOrder = order + descendantCount + 1;
+    const newIndex = generateNextIndex(index);
+
+    navigate('개요/edit', {
+      state: {
+        pageId,
+        parentPostId,
+        order: newOrder,
+        index: newIndex,
+        pageName,
+        postTitle,
+        content,
+        type: 'new',
+      },
+    });
+  };
+
+  // const handleAddChildPostClick = () => {
+  //   navigate('개요/edit', {
+  //     state: { pageId, parentPostId: 0, order: 1, index: '1.', pageName, postTitle: '개요', content: '', type: 'new' },
+  //   });
+  // };
 
   return (
     <div className='flex items-center justify-center mb-4 '>
@@ -23,7 +76,9 @@ const AddPostButton = () => {
       </Button>
       {isSplit && (
         <ButtonGroup color='white' fullWidth className='shadow-none border-gray-300 rounded-sm h-10'>
-          <Button className='bg-gray-50 text-gray-500 rounded-sm'>다음 목차로 추가</Button>
+          <Button className='bg-gray-50 text-gray-500 rounded-sm' onClick={handleAddNextPostClick}>
+            다음 목차로 추가
+          </Button>
           <Button className='bg-gray-50 text-gray-500 rounded-sm'>하위 목차로 추가</Button>
         </ButtonGroup>
       )}

--- a/src/components/Page/Post/AddPostButton.tsx
+++ b/src/components/Page/Post/AddPostButton.tsx
@@ -26,10 +26,16 @@ const generateNextIndex = (currentIndex: string) => {
   return parts.join('.');
 };
 
+const generateChildIndex = (currentIndex: string) => {
+  const parts = currentIndex.split('.');
+  parts.push('1');
+  return parts.join('.');
+};
+
 const AddPostButton = ({ post, pageId, pageName, descendantCount }: Props) => {
   const [isSplit, setIsSplit] = useState(false);
 
-  const { parentPostId, order, index, postTitle, content } = post;
+  const { postId, parentPostId, order, index } = post;
 
   const navigate = useNavigate();
 
@@ -50,18 +56,31 @@ const AddPostButton = ({ post, pageId, pageName, descendantCount }: Props) => {
         order: newOrder,
         index: newIndex,
         pageName,
-        postTitle,
-        content,
+        postTitle: '',
+        content: '',
         type: 'new',
       },
     });
   };
 
-  // const handleAddChildPostClick = () => {
-  //   navigate('개요/edit', {
-  //     state: { pageId, parentPostId: 0, order: 1, index: '1.', pageName, postTitle: '개요', content: '', type: 'new' },
-  //   });
-  // };
+  // 하위 목차에 추가하는 경우: parentPostId = 현재 포스트의 postId, order = 현재 order + 1, index = 현재 포스트 index 뒤에 .1 추가
+  const handleAddChildPostClick = () => {
+    const newOrder = order + 1;
+    const newIndex = generateChildIndex(index);
+
+    navigate('개요/edit', {
+      state: {
+        pageId,
+        parentPostId: postId,
+        order: newOrder,
+        index: newIndex,
+        pageName,
+        postTitle: '',
+        content: '',
+        type: 'new',
+      },
+    });
+  };
 
   return (
     <div className='flex items-center justify-center mb-4 '>
@@ -79,7 +98,9 @@ const AddPostButton = ({ post, pageId, pageName, descendantCount }: Props) => {
           <Button className='bg-gray-50 text-gray-500 rounded-sm' onClick={handleAddNextPostClick}>
             다음 목차로 추가
           </Button>
-          <Button className='bg-gray-50 text-gray-500 rounded-sm'>하위 목차로 추가</Button>
+          <Button className='bg-gray-50 text-gray-500 rounded-sm' onClick={handleAddChildPostClick}>
+            하위 목차로 추가
+          </Button>
         </ButtonGroup>
       )}
     </div>

--- a/src/components/Page/Post/Editor/Ckviewer.tsx
+++ b/src/components/Page/Post/Editor/Ckviewer.tsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import { CKEditor } from '@ckeditor/ckeditor5-react';
-import CustomEditor from 'ckeditor5-custom-build/build/ckeditor';
 import './Editor.css';
 
 interface ViewerProps {
@@ -10,19 +8,8 @@ interface ViewerProps {
 /* TODO 추후 ck editor에 맞게 변경 필요 */
 const Viewer = ({ content }: ViewerProps) => {
   return (
-    <div className='mb-4'>
-      <CKEditor
-        id='viewer'
-        editor={CustomEditor}
-        data={content}
-        disabled
-        onReady={(editor) => {
-          const toolbarElement = editor.ui.view.toolbar.element;
-          if (editor.isReadOnly && toolbarElement) {
-            toolbarElement.style.display = 'none';
-          }
-        }}
-      />
+    <div className='mb-4 px-1 py-2'>
+      <div className='ck-content ck-read-only' dangerouslySetInnerHTML={{ __html: content }} />
     </div>
   );
 };

--- a/src/components/Page/Post/Editor/Ckviewer.tsx
+++ b/src/components/Page/Post/Editor/Ckviewer.tsx
@@ -5,7 +5,7 @@ interface ViewerProps {
   content: string;
 }
 
-/* TODO 추후 ck editor에 맞게 변경 필요 */
+/* eslint-disable react/no-danger */
 const Viewer = ({ content }: ViewerProps) => {
   return (
     <div className='mb-4 px-1 py-2'>

--- a/src/components/Page/Post/Post.tsx
+++ b/src/components/Page/Post/Post.tsx
@@ -14,6 +14,7 @@ import { comments } from '@dummy/page';
 import CommentList from './CommentList';
 
 interface PostProps {
+  postId: number;
   pageId: number;
   pageName: string;
   index: string;
@@ -21,12 +22,11 @@ interface PostProps {
   content: string;
 }
 
-const Post = ({ pageId, pageName, index, postTitle, content }: PostProps) => {
+const Post = ({ postId, pageId, pageName, index, postTitle, content }: PostProps) => {
   const commentRef = useRef<HTMLDivElement>(null);
 
   const navigate = useNavigate();
   const [isCommentOpen, setIsCommentOpen] = useState<boolean>(false);
-  const postId = `${pageId}-${index}`;
 
   const handleCommentClick = () => {
     setIsCommentOpen((prev) => !prev);
@@ -36,7 +36,7 @@ const Post = ({ pageId, pageName, index, postTitle, content }: PostProps) => {
   };
 
   return (
-    <article id={postId}>
+    <article id={postId.toString()}>
       <div className='flex justify-between border-b-2'>
         <h2 className='text-xl leading-relaxed font-semibold'>
           <span className='text-indigo-500'>{index}</span> {postTitle}
@@ -61,7 +61,7 @@ const Post = ({ pageId, pageName, index, postTitle, content }: PostProps) => {
                 className='flex items-center gap-2 py-1'
                 onClick={() =>
                   navigate(`${postTitle}/edit`, {
-                    state: { pageId, index, pageName, postTitle, content },
+                    state: { postId, pageId, index, pageName, postTitle, content },
                   })
                 }
               >

--- a/src/pages/GroupMainPage.tsx
+++ b/src/pages/GroupMainPage.tsx
@@ -21,6 +21,9 @@ interface Post {
   parentPostId: number;
 }
 
+const countPostsWithPrefix = (postList: Post[], prefix: string) =>
+  postList.filter((post) => post.index.startsWith(prefix)).length;
+
 const GroupMainPage = () => {
   const navigate = useNavigate();
   const { groupId, page } = useParams();
@@ -81,7 +84,12 @@ const GroupMainPage = () => {
                       postTitle={post.postTitle}
                       content={post.content}
                     />
-                    <AddPostButton />
+                    <AddPostButton
+                      post={post}
+                      pageId={pageId}
+                      pageName={pageName}
+                      descendantCount={countPostsWithPrefix(postList, post.index)}
+                    />
                   </li>
                 ))}
               </ul>

--- a/src/pages/GroupMainPage.tsx
+++ b/src/pages/GroupMainPage.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useEffect } from 'react';
+import React, { Suspense } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { MdArrowCircleRight } from 'react-icons/md';
 import { v4 as uuidv4 } from 'uuid';
@@ -21,16 +21,6 @@ interface Post {
   parentPostId: number;
 }
 
-interface Error {
-  response: {
-    data: {
-      error: {
-        message: string;
-      };
-    };
-  };
-}
-
 const GroupMainPage = () => {
   const navigate = useNavigate();
   const { groupId, page } = useParams();
@@ -39,9 +29,12 @@ const GroupMainPage = () => {
   if (!groupId) return null;
   if (!page) return null;
 
-  const { data, error, status } = useQuery({
+  const { data, isLoading } = useQuery({
     queryKey: PAGE_KEYS.byTitle({ groupId: numGroupId, title: page }),
     queryFn: () => getPageByTitleFn({ groupId: numGroupId, title: page }),
+    onError: () => {
+      navigate('/404');
+    },
   });
 
   const { pageName, pageId, postList, goodCount, badCount } = data?.data?.response || {
@@ -52,18 +45,11 @@ const GroupMainPage = () => {
     badCount: 0,
   };
 
-  const handleWriteClick = () => {
+  const handleNewPostClick = () => {
     navigate('개요/edit', {
-      state: { pageId, index: '1.', pageName, postTitle: '개요', content: '' },
+      state: { pageId, parentPostId: 0, order: 1, index: '1.', pageName, postTitle: '개요', content: '', type: 'new' },
     });
   };
-
-  useEffect(() => {
-    if (error) console.log(error);
-    if (error && (error as Error).response.data.error.message === '존재하지 않는 페이지 입니다.') {
-      navigate('/404', { replace: true });
-    }
-  }, [data, error, status]);
 
   return (
     <Suspense fallback={<div>Loading...</div>}>
@@ -80,39 +66,43 @@ const GroupMainPage = () => {
             />
           }
         />
-        <PageContainer pageId={postList.length !== 0 ? pageId : undefined} hasRecentChangeList>
-          {postList.length !== 0 ? (
-            <ul>
-              {postList.map((post: Post) => (
-                <li key={uuidv4()}>
-                  <Post
-                    pageId={pageId}
-                    pageName={pageName}
-                    index={post.index}
-                    postTitle={post.postTitle}
-                    content={post.content}
-                  />
-                  <AddPostButton />
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <article className='flex justify-between items-center p-4 bg-gray-100 rounded-lg px-4'>
-              <p className='text-sm shrink-0'>
-                <span className='font-bold'>{`"${page}"`}</span>에 새로운 글을 작성해보세요!
-              </p>
-              <Button
-                variant='text'
-                ripple={false}
-                className='group flex items-center gap-1 py-1 px-2 text-sm font-bold hover:bg-transparent active:bg-transparent shrink-0'
-                onClick={handleWriteClick}
-              >
-                <span>글쓰기</span>
-                <MdArrowCircleRight className='w-5 h-5 group-hover:animate-arrowBounce' />
-              </Button>
-            </article>
-          )}
-        </PageContainer>
+        {isLoading ? (
+          <p>loading</p>
+        ) : (
+          <PageContainer pageId={postList.length !== 0 ? pageId : undefined} hasRecentChangeList>
+            {postList.length !== 0 ? (
+              <ul>
+                {postList.map((post: Post) => (
+                  <li key={uuidv4()}>
+                    <Post
+                      pageId={pageId}
+                      pageName={pageName}
+                      index={post.index}
+                      postTitle={post.postTitle}
+                      content={post.content}
+                    />
+                    <AddPostButton />
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <article className='flex justify-between items-center p-4 bg-gray-100 rounded-lg px-4'>
+                <p className='text-sm shrink-0'>
+                  <span className='font-bold'>{`"${page}"`}</span>에 새로운 글을 작성해보세요!
+                </p>
+                <Button
+                  variant='text'
+                  ripple={false}
+                  className='group flex items-center gap-1 py-1 px-2 text-sm font-bold hover:bg-transparent active:bg-transparent shrink-0'
+                  onClick={handleNewPostClick}
+                >
+                  <span>글쓰기</span>
+                  <MdArrowCircleRight className='w-5 h-5 group-hover:animate-arrowBounce' />
+                </Button>
+              </article>
+            )}
+          </PageContainer>
+        )}
       </div>
     </Suspense>
   );

--- a/src/pages/GroupMainPage.tsx
+++ b/src/pages/GroupMainPage.tsx
@@ -22,7 +22,7 @@ interface Post {
 }
 
 const countPostsWithPrefix = (postList: Post[], prefix: string) =>
-  postList.filter((post) => post.index.startsWith(prefix)).length;
+  postList.filter((post) => post.index.startsWith(`${prefix}.`)).length;
 
 const GroupMainPage = () => {
   const navigate = useNavigate();

--- a/src/pages/GroupMainPage.tsx
+++ b/src/pages/GroupMainPage.tsx
@@ -78,6 +78,7 @@ const GroupMainPage = () => {
                 {postList.map((post: Post) => (
                   <li key={uuidv4()}>
                     <Post
+                      postId={post.postId}
                       pageId={pageId}
                       pageName={pageName}
                       index={post.index}

--- a/src/pages/GroupMainPage.tsx
+++ b/src/pages/GroupMainPage.tsx
@@ -50,7 +50,7 @@ const GroupMainPage = () => {
 
   const handleNewPostClick = () => {
     navigate('개요/edit', {
-      state: { pageId, parentPostId: 0, order: 1, index: '1.', pageName, postTitle: '개요', content: '', type: 'new' },
+      state: { pageId, parentPostId: 0, order: 1, index: '1', pageName, postTitle: '개요', content: '', type: 'new' },
     });
   };
 

--- a/src/pages/PostEditPage.tsx
+++ b/src/pages/PostEditPage.tsx
@@ -10,32 +10,45 @@ import { useMutation } from '@tanstack/react-query';
 import { createPostFn } from '@apis/postApi';
 
 const PostEditPage = () => {
+  // url로 넘어온 group id
   const { groupId } = useParams();
   const numGroupId = Number(groupId);
+
+  // 페이지에서 넘어온 데이터
   const { pageId, parentPostId, order, index, pageName, postTitle, content: postContent, type } = useLocation().state;
-  const navigate = useNavigate();
+
   const [title, setTitle] = useState<string>(postTitle);
   const [content, setContent] = useState<string>(postContent);
+
+  const navigate = useNavigate();
   const deleteModal = useModal();
 
   const handleTitleChange = (e: ChangeEvent<HTMLInputElement>) => {
     setTitle(e.target.value);
   };
+
   const handleContentChange = (data: string) => {
     setContent(data);
   };
 
-  // 글을 새로 작성하는 경우
+  // 새로 작성
   const { mutate: createPost } = useMutation({
     mutationFn: () => createPostFn({ groupId: numGroupId, pageId, parentPostId, order, title, content }),
   });
 
+  // 수정
+  // const { mutate: updatePost } = useMutation({
+  //   mutationFn: () => modifyPostFn({ groupId: numGroupId, postId: 1, title, content }),
+  // });
+
   const handleSaveClick = () => {
-    // api 연결 후 작성
+    // 새로 작성하는 경우
     if (type === 'new') {
       createPost();
+    } else {
+      // 있던 글 수정하는 경우
     }
-    navigate(`/${groupId}/${pageName}`, { replace: true });
+    // navigate(`/${groupId}/${pageName}`, { replace: true });
   };
 
   return (

--- a/src/pages/PostEditPage.tsx
+++ b/src/pages/PostEditPage.tsx
@@ -7,7 +7,7 @@ import { Button, Input } from '@material-tailwind/react';
 import CKEditor from '@components/Page/Post/Editor/Ckeditor';
 import PostDeleteModal from '@components/Modal/PostDeleteModal';
 import { useMutation } from '@tanstack/react-query';
-import { createPostFn } from '@apis/postApi';
+import { createPostFn, modifyPostFn } from '@apis/postApi';
 
 const PostEditPage = () => {
   // url로 넘어온 group id
@@ -15,7 +15,17 @@ const PostEditPage = () => {
   const numGroupId = Number(groupId);
 
   // 페이지에서 넘어온 데이터
-  const { pageId, parentPostId, order, index, pageName, postTitle, content: postContent, type } = useLocation().state;
+  const {
+    postId,
+    pageId,
+    parentPostId,
+    order,
+    index,
+    pageName,
+    postTitle,
+    content: postContent,
+    type,
+  } = useLocation().state;
 
   const [title, setTitle] = useState<string>(postTitle);
   const [content, setContent] = useState<string>(postContent);
@@ -37,9 +47,9 @@ const PostEditPage = () => {
   });
 
   // 수정
-  // const { mutate: updatePost } = useMutation({
-  //   mutationFn: () => modifyPostFn({ groupId: numGroupId, postId: 1, title, content }),
-  // });
+  const { mutate: updatePost } = useMutation({
+    mutationFn: () => modifyPostFn({ groupId: numGroupId, postId, title, content }),
+  });
 
   const handleSaveClick = () => {
     // 새로 작성하는 경우
@@ -47,6 +57,7 @@ const PostEditPage = () => {
       createPost();
     } else {
       // 있던 글 수정하는 경우
+      updatePost();
     }
     navigate(-1);
   };

--- a/src/pages/PostEditPage.tsx
+++ b/src/pages/PostEditPage.tsx
@@ -2,13 +2,17 @@ import React, { ChangeEvent, useState } from 'react';
 import PageContainer from '@components/Page/Common/PageContainer';
 import PageTitleSection from '@components/Page/Common/PageTitleSection';
 import useModal from '@hooks/useModal';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { Button, Input } from '@material-tailwind/react';
 import CKEditor from '@components/Page/Post/Editor/Ckeditor';
 import PostDeleteModal from '@components/Modal/PostDeleteModal';
+import { useMutation } from '@tanstack/react-query';
+import { createPostFn } from '@apis/postApi';
 
 const PostEditPage = () => {
-  const { pageId, index, pageName, postTitle, content: postContent } = useLocation().state;
+  const { groupId } = useParams();
+  const numGroupId = Number(groupId);
+  const { pageId, parentPostId, order, index, pageName, postTitle, content: postContent, type } = useLocation().state;
   const navigate = useNavigate();
   const [title, setTitle] = useState<string>(postTitle);
   const [content, setContent] = useState<string>(postContent);
@@ -20,8 +24,18 @@ const PostEditPage = () => {
   const handleContentChange = (data: string) => {
     setContent(data);
   };
+
+  // 글을 새로 작성하는 경우
+  const { mutate: createPost } = useMutation({
+    mutationFn: () => createPostFn({ groupId: numGroupId, pageId, parentPostId, order, title, content }),
+  });
+
   const handleSaveClick = () => {
     // api 연결 후 작성
+    if (type === 'new') {
+      createPost();
+    }
+    navigate(`/${groupId}/${pageName}`, { replace: true });
   };
 
   return (
@@ -35,7 +49,7 @@ const PostEditPage = () => {
               className='!text-base !border !border-gray-400 bg-white rounded-md focus:!border-gray-700'
               crossOrigin=''
               value={title}
-              placeholder={`목차(${index}) 제목을 입력하세요.`}
+              placeholder='제목을 입력하세요.'
               labelProps={{
                 className: 'hidden',
               }}

--- a/src/pages/PostEditPage.tsx
+++ b/src/pages/PostEditPage.tsx
@@ -48,7 +48,7 @@ const PostEditPage = () => {
     } else {
       // 있던 글 수정하는 경우
     }
-    // navigate(`/${groupId}/${pageName}`, { replace: true });
+    navigate(-1);
   };
 
   return (


### PR DESCRIPTION
## ⭐Key Changes
> 핵심 변경 사항에 대해서 적어주세요.
1. 포스트 생성 및 수정 기능 구현
- 실제 API는 생성과 수정이 분리되어 있지만 프론트에서는 전부 editPage에서 처리하고 있기 때문에 분리하여 처리를 해주었습니다.
- 생성인지 수정인지는 url 넘겨줄 때 state의 type으로 구분합니다. type이 new로 존재하면 새로 작성입니다.
- 페이지의 첫 포스트는 반드시 index가 1, order가 1, parent가 0입니다.
- 다음 목차 생성을 눌렀을 때 order 계산이 복잡한데... 제가 테스트 할 때는 다 잘 작동했으나 혹시 이상한 부분을 찾는다면 알려주세요... 😢 

<br>

## 📌Issue
- Close #131 

<br>

## 👪To Reviewers
> reviewer에게 하고 싶은 말을 적어주세요.

test1 아이디로 로그인 한 후 group3의 세번째 페이지에 가면 제가 테스트한 흔적을 훔쳐보실 수(!) 있습니다.