### PR TITLE
포스트삭제 및 목차

### DIFF
--- a/src/apis/pageApi.ts
+++ b/src/apis/pageApi.ts
@@ -19,3 +19,6 @@ export const pageHateFn = ({ groupId, pageId }: { groupId: number; pageId: numbe
 
 export const searchPageFn = ({ groupId, keyword }: { groupId: number; keyword: string }) =>
   instance.get(`/group/${groupId}/page/search?keyword=${keyword}&page=1`);
+
+export const getIndexListFn = ({ groupId, pageId }: { groupId: number; pageId: number }) =>
+  instance.get(`/group/${groupId}/page/${pageId}/index`);

--- a/src/apis/postApi.ts
+++ b/src/apis/postApi.ts
@@ -29,3 +29,6 @@ export const modifyPostFn = ({
   title: string;
   content: string;
 }) => instance.put(`/group/${groupId}/post/modify`, { postId, title, content });
+
+export const deletePostFn = ({ groupId, postId }: { groupId: number; postId: number }) =>
+  instance.delete(`/group/${groupId}/post/${postId}`);

--- a/src/components/Common/ScrollToTop.tsx
+++ b/src/components/Common/ScrollToTop.tsx
@@ -1,0 +1,44 @@
+import { IconButton } from '@material-tailwind/react';
+import React, { useState, useEffect } from 'react';
+import { MdArrowUpward } from 'react-icons/md';
+
+const ScrollToTopButton = () => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  };
+
+  useEffect(() => {
+    const handleShowButton = () => {
+      if (window.scrollY > 500) {
+        setIsVisible(true);
+      } else {
+        setIsVisible(false);
+      }
+    };
+
+    window.addEventListener('scroll', handleShowButton);
+    return () => {
+      window.removeEventListener('scroll', handleShowButton);
+    };
+  }, []);
+
+  return (
+    <div className='fixed bottom-5 right-5'>
+      {isVisible && (
+        <IconButton
+          className=' bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-full shadow-md'
+          onClick={scrollToTop}
+        >
+          <MdArrowUpward className='w-5 h-5' />
+        </IconButton>
+      )}
+    </div>
+  );
+};
+
+export default ScrollToTopButton;

--- a/src/components/Modal/PostDeleteModal.tsx
+++ b/src/components/Modal/PostDeleteModal.tsx
@@ -26,7 +26,7 @@ const PostDeleteModal = ({ title, isOpen, onClickModal, groupId, postId, pageNam
     mutationFn: () => deletePostFn({ groupId, postId }),
     onSuccess: () => {
       onClickModal();
-      navigate(`${groupId}/${pageName}`, { replace: true });
+      navigate(`/${groupId}/${pageName}`, { replace: true });
     },
     onError: (error: AxiosError) => {
       // 에러 처리, 삭제 버튼 위에 tip으로 미리 해당사항 알려주기

--- a/src/components/Modal/PostDeleteModal.tsx
+++ b/src/components/Modal/PostDeleteModal.tsx
@@ -1,25 +1,54 @@
 import React, { useState } from 'react';
 import { Dialog, DialogHeader, DialogBody, DialogFooter, Button, Checkbox } from '@material-tailwind/react';
+import { useMutation } from '@tanstack/react-query';
+import { deletePostFn } from '@apis/postApi';
+import { AxiosError } from 'axios';
+import { useNavigate } from 'react-router-dom';
 
 interface PostDeleteModalProps {
   title: string;
   isOpen: boolean;
   onClickModal: () => void;
+  groupId: number;
+  postId: number;
+  pageName: string | undefined;
 }
 
 const CONFIRMTEXT = '위의 내용을 확인하였으며 삭제 동의';
 
-const PostDeleteModal = ({ title, isOpen, onClickModal }: PostDeleteModalProps) => {
+const PostDeleteModal = ({ title, isOpen, onClickModal, groupId, postId, pageName }: PostDeleteModalProps) => {
   const [isChecked, setIsChecked] = useState<boolean>(false);
+  const [errorMessage, setErrorMessage] = useState<string>('');
 
-  const handleCheck = () => {
-    setIsChecked((prev) => !prev);
-  };
+  const navigate = useNavigate();
+
+  const { mutate: deletePost } = useMutation({
+    mutationFn: () => deletePostFn({ groupId, postId }),
+    onSuccess: () => {
+      onClickModal();
+      navigate(`${groupId}/${pageName}`, { replace: true });
+    },
+    onError: (error: AxiosError) => {
+      // 에러 처리, 삭제 버튼 위에 tip으로 미리 해당사항 알려주기
+      if (error.response && error.response.status === 400) {
+        console.log('400 error');
+        setErrorMessage('하위문서를 모두 삭제한 후 진행해주세요.');
+      } else {
+        // 그룹 또는 페이지가 없거나 회원이 아니거나 하는 경우 모두 404로 처리
+        alert('잘못된 요청입니다.');
+        onClickModal();
+        navigate('/404', { replace: true });
+      }
+    },
+  });
+
   const handleDeleteClick = () => {
     if (!isChecked) return;
-    onClickModal();
-    // 이부분은 실제 코드 만들때 삭제!
-    handleCheck();
+    deletePost();
+  };
+
+  const handleCheckboxChange = () => {
+    setIsChecked((prev) => !prev);
   };
 
   return (
@@ -34,6 +63,7 @@ const PostDeleteModal = ({ title, isOpen, onClickModal }: PostDeleteModalProps) 
           포스트를 삭제하면 <span className='text-black font-semibold'>복구할 수 없으며</span>,
           <br /> 포스트에 해당하는 <span className='text-black font-semibold'>내용과 히스토리가 모두 삭제</span>됩니다.
         </p>
+        {errorMessage && <p className='text-center text-red-600 mb-2 font-bold bg-red-50 px-2'>{errorMessage}</p>}
         <Checkbox
           label={CONFIRMTEXT}
           ripple={false}
@@ -42,11 +72,19 @@ const PostDeleteModal = ({ title, isOpen, onClickModal }: PostDeleteModalProps) 
           labelProps={{
             className: 'text-gray-600 text-sm',
           }}
-          onClick={handleCheck}
+          checked={isChecked}
+          onChange={handleCheckboxChange}
         />
       </DialogBody>
       <DialogFooter className='pt-0'>
-        <Button variant='text' ripple={false} color='red' onClick={handleDeleteClick} className='mr-1'>
+        <Button
+          variant='filled'
+          ripple={false}
+          color={isChecked ? 'red' : 'gray'}
+          onClick={handleDeleteClick}
+          className='mr-1'
+          disabled={!isChecked}
+        >
           <span>삭제</span>
         </Button>
         <Button variant='filled' ripple={false} onClick={onClickModal}>

--- a/src/components/Modal/PostDeleteModal.tsx
+++ b/src/components/Modal/PostDeleteModal.tsx
@@ -31,7 +31,6 @@ const PostDeleteModal = ({ title, isOpen, onClickModal, groupId, postId, pageNam
     onError: (error: AxiosError) => {
       // 에러 처리, 삭제 버튼 위에 tip으로 미리 해당사항 알려주기
       if (error.response && error.response.status === 400) {
-        console.log('400 error');
         setErrorMessage('하위문서를 모두 삭제한 후 진행해주세요.');
       } else {
         // 그룹 또는 페이지가 없거나 회원이 아니거나 하는 경우 모두 404로 처리

--- a/src/components/Page/Common/IndexList.tsx
+++ b/src/components/Page/Common/IndexList.tsx
@@ -40,17 +40,20 @@ const IndexList = ({ pageId }: IndexListProps) => {
         {isLoading ? (
           <div>Loading...</div>
         ) : (
-          <ul className='p-2 bg-gray-100 text-xs whitespace-pre'>
+          <ul className='p-2 bg-gray-100 text-xs xl:overflow-auto max-h-[65vh] lg:overflow-hidden scroll'>
             {postList.length !== 0 &&
               postList.map((post: Post) => (
-                <li key={uuidv4()} className='m-2 leading-tight'>
-                  {'  '.repeat(post.index.split('.').length - 1)}
+                <li key={uuidv4()} className='m-2 leading-tight overflow-hidden'>
                   <button
                     type='button'
                     onClick={() => scrollToPost(post.postId.toString())}
                     className='whitespace-break-spaces text-left'
                   >
-                    <span className='text-indigo-500'>{post.index}</span> {post.postTitle}
+                    <span className='text-indigo-500'>
+                      {'  '.repeat(post.index.split('.').length - 1)}
+                      {post.index}
+                    </span>{' '}
+                    {post.postTitle}
                   </button>
                 </li>
               ))}

--- a/src/components/Page/Common/IndexList.tsx
+++ b/src/components/Page/Common/IndexList.tsx
@@ -40,11 +40,11 @@ const IndexList = ({ pageId }: IndexListProps) => {
         {isLoading ? (
           <div>Loading...</div>
         ) : (
-          <ul className='p-4 bg-gray-100 text-xs'>
+          <ul className='p-2 bg-gray-100 text-xs whitespace-pre'>
             {postList.length !== 0 &&
               postList.map((post: Post) => (
-                <li key={uuidv4()} className='my-2 leading-tight whitespace-pre'>
-                  {post.index.split('.').length > 1 && '  '}
+                <li key={uuidv4()} className='m-2 leading-tight'>
+                  {'  '.repeat(post.index.split('.').length - 1)}
                   <button
                     type='button'
                     onClick={() => scrollToPost(post.postId.toString())}

--- a/src/components/Page/Common/IndexList.tsx
+++ b/src/components/Page/Common/IndexList.tsx
@@ -16,7 +16,6 @@ interface Post {
 }
 
 const scrollToPost = (postId: string) => {
-  console.log(postId);
   const postElement = document.getElementById(postId);
   if (postElement) {
     window.scrollTo({ top: postElement.offsetTop - 60, behavior: 'smooth' });

--- a/src/components/Page/Common/IndexList.tsx
+++ b/src/components/Page/Common/IndexList.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
 import { getIndexListFn } from '@apis/pageApi';
 import { useQuery } from '@tanstack/react-query';
+import { PAGE_KEYS } from '@constants/queryKeys';
 
 interface IndexListProps {
   pageId: number;
@@ -27,7 +28,7 @@ const IndexList = ({ pageId }: IndexListProps) => {
   const numGroupId = Number(groupId.groupId);
 
   const { data, isLoading } = useQuery({
-    queryKey: ['indexList', numGroupId, pageId],
+    queryKey: PAGE_KEYS.indexList({ groupId: numGroupId, pageId }),
     queryFn: () => getIndexListFn({ groupId: numGroupId, pageId }),
   });
 

--- a/src/components/Page/Common/IndexList.tsx
+++ b/src/components/Page/Common/IndexList.tsx
@@ -1,36 +1,63 @@
-import React from 'react';
+import React, { Suspense } from 'react';
+import { useParams } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
-import { getIndexList } from '@dummy/page';
+import { getIndexListFn } from '@apis/pageApi';
+import { useQuery } from '@tanstack/react-query';
 
 interface IndexListProps {
   pageId: number;
 }
 
-const IndexList = ({ pageId }: IndexListProps) => {
-  const indexList = getIndexList(pageId);
+interface Post {
+  postId: number;
+  index: string;
+  postTitle: string;
+}
 
-  const scrollToPost = (postId: string) => {
-    console.log(postId);
-    const postElement = document.getElementById(postId);
-    if (postElement) {
-      window.scrollTo({ top: postElement.offsetTop - 60, behavior: 'smooth' });
-    }
-  };
+const scrollToPost = (postId: string) => {
+  console.log(postId);
+  const postElement = document.getElementById(postId);
+  if (postElement) {
+    window.scrollTo({ top: postElement.offsetTop - 60, behavior: 'smooth' });
+  }
+};
+
+const IndexList = ({ pageId }: IndexListProps) => {
+  const groupId = useParams<{ groupId: string }>();
+  const numGroupId = Number(groupId.groupId);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['indexList', numGroupId, pageId],
+    queryFn: () => getIndexListFn({ groupId: numGroupId, pageId }),
+  });
+
+  const { postList } = data?.data?.response || { postList: [] };
 
   return (
-    <div className='w-full'>
-      <h2 className='font-bold px-1 py-2 text-sm'>목차</h2>
-      <ul className='p-4 bg-gray-100 text-xs'>
-        {indexList.map((post) => (
-          <li key={uuidv4()} className='my-2 leading-tight whitespace-pre'>
-            {post.index.split('.').length > 2 && '  '}
-            <button type='button' onClick={() => scrollToPost(`${pageId}-${post.index}`)}>
-              <span className='text-indigo-500'>{post.index}</span> {post.postTitle}
-            </button>
-          </li>
-        ))}
-      </ul>
-    </div>
+    <Suspense fallback={<div>Loading...</div>}>
+      <div className='w-full'>
+        <h2 className='font-bold px-1 py-2 text-sm'>목차</h2>
+        {isLoading ? (
+          <div>Loading...</div>
+        ) : (
+          <ul className='p-4 bg-gray-100 text-xs'>
+            {postList.length !== 0 &&
+              postList.map((post: Post) => (
+                <li key={uuidv4()} className='my-2 leading-tight whitespace-pre'>
+                  {post.index.split('.').length > 1 && '  '}
+                  <button
+                    type='button'
+                    onClick={() => scrollToPost(post.postId.toString())}
+                    className='whitespace-break-spaces text-left'
+                  >
+                    <span className='text-indigo-500'>{post.index}</span> {post.postTitle}
+                  </button>
+                </li>
+              ))}
+          </ul>
+        )}
+      </div>
+    </Suspense>
   );
 };
 

--- a/src/components/Page/Common/IndexList.tsx
+++ b/src/components/Page/Common/IndexList.tsx
@@ -40,7 +40,7 @@ const IndexList = ({ pageId }: IndexListProps) => {
         {isLoading ? (
           <div>Loading...</div>
         ) : (
-          <ul className='p-2 bg-gray-100 text-xs xl:overflow-auto max-h-[65vh] lg:overflow-hidden scroll'>
+          <ul className='p-2 bg-gray-100 text-xs xl:overflow-auto xl:max-h-[65vh] overflow-hidden scroll'>
             {postList.length !== 0 &&
               postList.map((post: Post) => (
                 <li key={uuidv4()} className='m-2 leading-tight overflow-hidden'>

--- a/src/components/Page/Common/PageContainer.tsx
+++ b/src/components/Page/Common/PageContainer.tsx
@@ -12,7 +12,7 @@ const PageContainer = ({ children, pageId, hasRecentChangeList }: PageContainerP
   return (
     <div className='mx-auto flex w-full max-w-full flex-col xl:flex-row items-start justify-center gap-4 xl:gap-6 2xl:gap-10 px-8 py-10'>
       {pageId && (
-        <aside className='w-full top-20 xl:w-44 xl:sticky 2xl:w-52 shrink-0'>
+        <aside className='w-full top-20 xl:w-48 xl:sticky 2xl:w-60 shrink-0'>
           <IndexList pageId={pageId} />
         </aside>
       )}

--- a/src/components/Page/Common/PageContainer.tsx
+++ b/src/components/Page/Common/PageContainer.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ScrollToTopButton from '@components/Common/ScrollToTop';
 import RecentChangeList from './RecentChangeList';
 import IndexList from './IndexList';
 
@@ -22,6 +23,7 @@ const PageContainer = ({ children, pageId, hasRecentChangeList }: PageContainerP
           <RecentChangeList />
         </aside>
       )}
+      <ScrollToTopButton />
     </div>
   );
 };

--- a/src/components/Page/Post/Post.tsx
+++ b/src/components/Page/Post/Post.tsx
@@ -60,8 +60,8 @@ const Post = ({ postId, pageId, pageName, index, postTitle, content }: PostProps
               <MenuItem
                 className='flex items-center gap-2 py-1'
                 onClick={() =>
-                  navigate(`${postTitle}/edit`, {
-                    state: { postId, pageId, index, pageName, postTitle, content },
+                  navigate(`${postId}/edit`, {
+                    state: { pageId, index, pageName, postTitle, content },
                   })
                 }
               >

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -3,6 +3,7 @@ export const PAGE_KEYS = {
   recentChangeList: ({ groupId }: { groupId: number }) => ['recentChangeList', { groupId }] as const,
   searchKeyword: ({ groupId, keyword }: { groupId: number; keyword: string }) =>
     ['searchKeyword', { groupId, keyword }] as const,
+  indexList: ({ groupId, pageId }: { groupId: number; pageId: number }) => ['indexList', { groupId, pageId }] as const,
 };
 
 export const MAIN_KEYS = {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -100,7 +100,7 @@ const router = createBrowserRouter([
             element: <GroupMainPage />,
           },
           {
-            path: '/:groupId/:page/:post/edit',
+            path: '/:groupId/:page/:postId/edit',
             element: <PostEditPage />,
           },
         ],

--- a/src/pages/GroupMainPage.tsx
+++ b/src/pages/GroupMainPage.tsx
@@ -56,7 +56,7 @@ const GroupMainPage = () => {
 
   return (
     <Suspense fallback={<div>Loading...</div>}>
-      <div className='mx-auto 2xl:max-w-screen-xl xl:max-w-screen-lg'>
+      <div className='mx-auto 2xl:max-w-screen-2xl xl:max-w-screen-xl'>
         <PageTitleSection
           title={pageName}
           aboveAdornment={

--- a/src/pages/PostEditPage.tsx
+++ b/src/pages/PostEditPage.tsx
@@ -15,6 +15,10 @@ const PostEditPage = () => {
   const numGroupId = Number(groupId);
   const postId = Number(post);
 
+  window.scrollTo({ top: 0, behavior: 'instant' });
+
+  if (!groupId || !page) return null;
+
   // 페이지에서 넘어온 데이터
   const { pageId, parentPostId, order, index, pageName, postTitle, content: postContent, type } = useLocation().state;
 
@@ -42,15 +46,15 @@ const PostEditPage = () => {
     mutationFn: () => modifyPostFn({ groupId: numGroupId, postId, title, content }),
   });
 
-  const handleSaveClick = () => {
+  const handleSaveClick = async () => {
     // 새로 작성하는 경우
     if (type === 'new') {
-      createPost();
+      await createPost();
     } else {
       // 있던 글 수정하는 경우
-      updatePost();
+      await updatePost();
     }
-    navigate(`${groupId}/${page}`, { replace: true });
+    navigate(`/${groupId}/${page}`, { replace: true });
   };
 
   return (

--- a/src/pages/PostEditPage.tsx
+++ b/src/pages/PostEditPage.tsx
@@ -76,21 +76,24 @@ const PostEditPage = () => {
             />
           </div>
           <CKEditor content={content} onChange={handleContentChange} />
-          <div className='flex justify-between'>
-            <Tooltip
-              content='하위 목차가 존재하지 않는 포스트만 가능합니다.'
-              placement='bottom'
-              className='border border-blue-gray-50 bg-white px-4 py-3 shadow-xl shadow-black/10 text-black'
-            >
-              <Button
-                variant='text'
-                ripple={false}
-                className='py-1 px-3 text-red-600 hover:bg-transparent hover:underline active:bg-transparent decoration-black'
-                onClick={deleteModal.handleModal}
+          <div className={`flex justify-between ${type === 'new' && 'flex-row-reverse'}`}>
+            {type !== 'new' && (
+              <Tooltip
+                content='하위 목차가 존재하지 않는 포스트만 가능합니다.'
+                placement='bottom'
+                className='border border-blue-gray-50 bg-white px-4 py-3 shadow-xl shadow-black/10 text-black'
               >
-                삭제하기
-              </Button>
-            </Tooltip>
+                <Button
+                  variant='text'
+                  ripple={false}
+                  className='py-1 px-3 text-red-600 hover:bg-transparent hover:underline active:bg-transparent decoration-black'
+                  onClick={deleteModal.handleModal}
+                >
+                  삭제하기
+                </Button>
+              </Tooltip>
+            )}
+
             <div className='flex gap-3'>
               <Button
                 color='white'

--- a/src/pages/PostEditPage.tsx
+++ b/src/pages/PostEditPage.tsx
@@ -3,29 +3,20 @@ import PageContainer from '@components/Page/Common/PageContainer';
 import PageTitleSection from '@components/Page/Common/PageTitleSection';
 import useModal from '@hooks/useModal';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
-import { Button, Input } from '@material-tailwind/react';
+import { Button, Input, Tooltip } from '@material-tailwind/react';
 import CKEditor from '@components/Page/Post/Editor/Ckeditor';
 import PostDeleteModal from '@components/Modal/PostDeleteModal';
 import { useMutation } from '@tanstack/react-query';
 import { createPostFn, modifyPostFn } from '@apis/postApi';
 
 const PostEditPage = () => {
-  // url로 넘어온 group id
-  const { groupId } = useParams();
+  // url로 넘어온 group id, post id
+  const { page, groupId, postId: post } = useParams();
   const numGroupId = Number(groupId);
+  const postId = Number(post);
 
   // 페이지에서 넘어온 데이터
-  const {
-    postId,
-    pageId,
-    parentPostId,
-    order,
-    index,
-    pageName,
-    postTitle,
-    content: postContent,
-    type,
-  } = useLocation().state;
+  const { pageId, parentPostId, order, index, pageName, postTitle, content: postContent, type } = useLocation().state;
 
   const [title, setTitle] = useState<string>(postTitle);
   const [content, setContent] = useState<string>(postContent);
@@ -59,7 +50,7 @@ const PostEditPage = () => {
       // 있던 글 수정하는 경우
       updatePost();
     }
-    navigate(-1);
+    navigate(`${groupId}/${page}`, { replace: true });
   };
 
   return (
@@ -82,14 +73,20 @@ const PostEditPage = () => {
           </div>
           <CKEditor content={content} onChange={handleContentChange} />
           <div className='flex justify-between'>
-            <Button
-              variant='text'
-              ripple={false}
-              className='py-1 px-3 text-red-600 hover:bg-transparent hover:underline active:bg-transparent decoration-black'
-              onClick={deleteModal.handleModal}
+            <Tooltip
+              content='하위 목차가 존재하지 않는 포스트만 가능합니다.'
+              placement='bottom'
+              className='border border-blue-gray-50 bg-white px-4 py-3 shadow-xl shadow-black/10 text-black'
             >
-              삭제하기
-            </Button>
+              <Button
+                variant='text'
+                ripple={false}
+                className='py-1 px-3 text-red-600 hover:bg-transparent hover:underline active:bg-transparent decoration-black'
+                onClick={deleteModal.handleModal}
+              >
+                삭제하기
+              </Button>
+            </Tooltip>
             <div className='flex gap-3'>
               <Button
                 color='white'
@@ -104,7 +101,14 @@ const PostEditPage = () => {
               </Button>
             </div>
           </div>
-          <PostDeleteModal title={title} isOpen={deleteModal.isOpen} onClickModal={deleteModal.handleModal} />
+          <PostDeleteModal
+            title={title}
+            isOpen={deleteModal.isOpen}
+            onClickModal={deleteModal.handleModal}
+            groupId={numGroupId}
+            postId={postId}
+            pageName={page}
+          />
         </article>
       </PageContainer>
     </div>

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -13,3 +13,13 @@
 .font-nanum {
   font-family: 'NanumSquare', system-ui, sans-serif;
 }
+
+/* ( 크롬, 사파리, 오페라, 엣지 ) 동작 */
+.scroll::-webkit-scrollbar {
+  display: none;
+}
+
+.scroll {
+  -ms-overflow-style: none; /* 인터넷 익스플로러 */
+  scrollbar-width: none; /* 파이어폭스 */
+}


### PR DESCRIPTION
## ⭐Key Changes
> 핵심 변경 사항에 대해서 적어주세요.
1. 포스트 삭제 구현

![image](https://github.com/Step3-kakao-tech-campus/Team8_FE/assets/48706964/86f95c2f-f235-4bec-867e-99184b2aad71)
- 삭제하기에 마우스 올리면 간단한 안내문 미리 표시

![image](https://github.com/Step3-kakao-tech-campus/Team8_FE/assets/48706964/4b992da9-b766-4533-a207-6f8c77cfebb8)
![image](https://github.com/Step3-kakao-tech-campus/Team8_FE/assets/48706964/d2eedd54-c100-4b12-a1c2-9978fb84f41e)
- 그런데도 눌렀으면 안내메세지를 모달에 출력합니다. 잘 보이게 빨간색으로
- 삭제하기 버튼 누르기 전에 API를 내려받지 않고 하위 포스트가 있는지 없는지 판단하려면 자손 수를 그룹 내 페이지 -> 포스트 컴포넌트 -> 포스트 수정 페이지까지 내려준 후 처리하는 방법이 있긴 합니다만 지금도 나쁘지 않지 않나요(?)
- 하지만 어쨌든 API 객체 내려받았을 때 에러 처리도 따로 해줘야해서... 간단히 안내 툴팁을 띄워주는 것으로 스스로 타협했어요.

2. 목차 구현
![image](https://github.com/Step3-kakao-tech-campus/Team8_FE/assets/48706964/9e1cc5f5-4497-4b14-bbd3-92301dddc7d0)

- 원래 한 자리까지만 들여쓰기 하려고 했는데...! 막상 보니 너무 정신없어서 그냥 다 들여쓰기 하는 걸로 변경했습니다.

![image](https://github.com/Step3-kakao-tech-campus/Team8_FE/assets/48706964/c73e1cac-2a0b-40e6-86a8-8ca49ddb2eff)

- 목차가 위아래로 너무 길어지면 잘려서 볼 수 없는 바람에 최대 높이를 설정한 후, 스크롤 기능은 남겨두고 스크롤바는 없애주었습니다.
- 양옆으로 길어지는 경우는... 음 일단 줄바꿈 되게 해뒀는데 저정도로 목차를 만드는 사람이 있다면? 그건 그 사용자가 감당해야할 문제라고 생각합니다. 못생김을 감당하세요.

![image](https://github.com/Step3-kakao-tech-campus/Team8_FE/assets/48706964/3dd06b6f-e413-4953-a1f2-fbc326768a53)

- 밑으로 어느 정도 내리면 저만큼 빈공간이 생기는데, 많이 어색하지 않은 것 같아서 따로 처리는 안 해주었습니다.
- 우측 하단에 ToTop 버튼을 만들어 페이지 스크롤이 일정 값 이상 내려가면 버튼이 뜨게 만들었습니다. 해당 버튼은 페이지 컨테이너에 있습니다!
- 검은색으로 통일하니까 너무 심심하고 칙칙해보여서 목차랑 비슷하게 파란색으로 만들어주었습니다.

<br>

## 📌Issue
- Close #145 

<br>

## 👪To Reviewers
> reviewer에게 하고 싶은 말을 적어주세요.

- Top으로 가는 버튼이...!!!!! 왠지 10% 정도의 확률로 찔끔 올라가고 멈추는데 도저히 이유를 못찾겠습니다... ㅋㅋㅠㅠ (이정도 확률이면 그냥 어 안눌러졌네 하고 한번 더 누르면 해결되지 않을까요) 혹시 해결책을 찾으신 분은 알려주세요
- 왜 나무위키가 목차를 최상단에 고정으로 박아버렸는지 알 것 같습니다. 무슨 짓을 해도 답이 없습니다. 옆에서 서랍형으로 튀어나오게 하려면 그것 또한 계속 열었다 닫았다해서 불편하더라고요? 그렇다고 아예 width를 없앴다 늘렸다하니까 본문이 눌렸다 풀렸다 고무줄마냥 왔다리갔다리해서 그것도 보기싫고... 고뇌하는 시간에 다른거 하나 더 만들자 싶어서 여기서 스톱함


<br>