### PR TITLE
대표 닉네임 변경

### DIFF
--- a/src/apis/authApi.ts
+++ b/src/apis/authApi.ts
@@ -23,3 +23,6 @@ export const passwordChangeFn = ({ currentPassword, newPassword }: { currentPass
   instance.patch(`${ENDPOINT}/password/change`, { currentPassword, newPassword });
 
 export const getMyInfoFn = () => instance.get(`${ENDPOINT}/myinfo`).then(({ data }) => data.response);
+
+export const nickNameChangeFn = ({ newNickName }: { newNickName: string }) =>
+  instance.patch(`${ENDPOINT}/changename`, { newNickName });

--- a/src/components/MyPage/ContributeList.tsx
+++ b/src/components/MyPage/ContributeList.tsx
@@ -19,9 +19,9 @@ const ContributeList = ({ contributeItems }: { contributeItems: ContributeItemPr
   return (
     <article className='p-4 max-h-[503px] border border-gray-400 overflow-y-auto'>
       <ul className='flex flex-col gap-4'>
-        {contributeItems.slice(0, 3).map((contributeItem) => (
-          <ContributeItem key={uuidv4()} contributeItem={contributeItem} />
-        ))}
+        {contributeItems
+          ?.slice(0, 3)
+          .map((contributeItem) => <ContributeItem key={uuidv4()} contributeItem={contributeItem} />)}
       </ul>
     </article>
   );

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -19,7 +19,7 @@ const MyPage = () => {
     setNickName(e.target.value);
   };
 
-  const handleNickNameChange = () => {
+  const handleIsNickNameChanging = () => {
     setIsNickNameChanging((prev) => !prev);
   };
 
@@ -58,7 +58,7 @@ const MyPage = () => {
                   variant='outlined'
                   color='gray'
                   className='ml-4 rounded-sm py-[11px] whitespace-nowrap hover:opacity-100'
-                  onClick={handleNickNameChange}
+                  onClick={handleIsNickNameChanging}
                 >
                   취소
                 </Button>
@@ -66,7 +66,7 @@ const MyPage = () => {
                   variant='outlined'
                   color='gray'
                   className='ml-2 rounded-sm py-[11px] whitespace-nowrap hover:opacity-100'
-                  onClick={handleNickNameChange}
+                  onClick={handleIsNickNameChanging}
                 >
                   변경하기
                 </Button>
@@ -76,7 +76,7 @@ const MyPage = () => {
                 variant='outlined'
                 color='gray'
                 className='ml-4 rounded-sm py-[11px] whitespace-nowrap'
-                onClick={handleNickNameChange}
+                onClick={handleIsNickNameChanging}
               >
                 변경하기
               </Button>

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -49,6 +49,7 @@ const MyPage = () => {
                 className: 'hidden',
               }}
               containerProps={{ className: 'min-w-[100px] max-w-[240px]' }}
+              disabled={!isNickNameChanging}
               onChange={handleNickName}
             />
             {isNickNameChanging ? (

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -3,17 +3,22 @@ import useModal from '@hooks/useModal';
 import { Button, Input } from '@material-tailwind/react';
 import GroupList from '@components/Home/GroupList';
 import PasswordChangeModal from '@components/Modal/PasswordChangeModal';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { AUTH_KEYS } from '@constants/queryKeys';
-import { getMyInfoFn } from '@apis/authApi';
+import { getMyInfoFn, nickNameChangeFn } from '@apis/authApi';
 import { MyInfo } from '@apis/dto';
+import { NAME_PATTERN } from '@constants/validationPatterns';
+import { NAME_ERROR_MSG } from '@constants/errorMsg';
+import { getErrorMsg } from '@utils/serverError';
 
 const MyPage = () => {
   const [nickName, setNickName] = useState('');
   const [isNickNameChanging, setIsNickNameChanging] = useState<boolean>(false);
+  const [errorMsg, setErrorMsg] = useState('');
   const passwordChangeModal = useModal();
 
   const { data: myInfo } = useQuery<MyInfo>({ queryKey: AUTH_KEYS.myInfo, queryFn: getMyInfoFn });
+  const { mutate: nickNameChange } = useMutation({ mutationFn: nickNameChangeFn });
 
   const handleNickName = (e: ChangeEvent<HTMLInputElement>) => {
     setNickName(e.target.value);
@@ -21,6 +26,34 @@ const MyPage = () => {
 
   const handleIsNickNameChanging = () => {
     setIsNickNameChanging((prev) => !prev);
+  };
+
+  const handleCancelClick = () => {
+    if (myInfo) {
+      setNickName(myInfo.mainNickName);
+    }
+    setErrorMsg('');
+    handleIsNickNameChanging();
+  };
+
+  const handleNickNameChange = () => {
+    if (!NAME_PATTERN.test(nickName)) {
+      setErrorMsg(NAME_ERROR_MSG);
+      return;
+    }
+
+    nickNameChange(
+      { newNickName: nickName },
+      {
+        onSuccess: () => {
+          setErrorMsg('');
+          handleIsNickNameChanging();
+        },
+        onError: (error) => {
+          setErrorMsg(getErrorMsg(error) ?? '');
+        },
+      },
+    );
   };
 
   useEffect(() => {
@@ -38,28 +71,30 @@ const MyPage = () => {
         <div className='flex items-baseline'>
           <span className='font-extrabold w-40'>대표 닉네임</span>
           <div className='flex items-center grow'>
-            <Input
-              type='text'
-              label='대표 닉네임'
-              value={nickName}
-              crossOrigin={undefined}
-              placeholder='대표 닉네임'
-              className='!border !border-t-blue-gray-200 text-gray-900 rounded-sm placeholder:text-gray-500 focus:!border-gray-900 focus:!border-t-gray-900'
-              labelProps={{
-                className: 'hidden',
-              }}
-              containerProps={{ className: 'min-w-[100px] max-w-[240px]' }}
-              disabled={!isNickNameChanging}
-              onChange={handleNickName}
-            />
+            <div className='relative'>
+              <Input
+                type='text'
+                label='대표 닉네임'
+                value={nickName}
+                crossOrigin={undefined}
+                placeholder='대표 닉네임'
+                className='!border !border-t-blue-gray-200 text-gray-900 rounded-sm placeholder:text-gray-500 focus:!border-gray-900 focus:!border-t-gray-900'
+                labelProps={{
+                  className: 'hidden',
+                }}
+                containerProps={{ className: 'min-w-[100px] max-w-[240px]' }}
+                disabled={!isNickNameChanging}
+                onChange={handleNickName}
+              />
+              {errorMsg && <p className='absolute -bottom-5 text-xs mx-1 flex items-center text-error'>{errorMsg}</p>}
+            </div>
             {isNickNameChanging ? (
               <>
-                {/* 취소, 변경처리는 api되면 생각해보기로.. */}
                 <Button
                   variant='outlined'
                   color='gray'
                   className='ml-4 rounded-sm py-[11px] whitespace-nowrap hover:opacity-100'
-                  onClick={handleIsNickNameChanging}
+                  onClick={handleCancelClick}
                 >
                   취소
                 </Button>
@@ -67,7 +102,7 @@ const MyPage = () => {
                   variant='outlined'
                   color='gray'
                   className='ml-2 rounded-sm py-[11px] whitespace-nowrap hover:opacity-100'
-                  onClick={handleIsNickNameChanging}
+                  onClick={handleNickNameChange}
                 >
                   변경하기
                 </Button>

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -19,7 +19,7 @@ const MyPage = () => {
     setNickName(e.target.value);
   };
 
-  const handleNickNameChage = () => {
+  const handleNickNameChange = () => {
     setIsNickNameChanging((prev) => !prev);
   };
 
@@ -58,7 +58,7 @@ const MyPage = () => {
                   variant='outlined'
                   color='gray'
                   className='ml-4 rounded-sm py-[11px] whitespace-nowrap hover:opacity-100'
-                  onClick={handleNickNameChage}
+                  onClick={handleNickNameChange}
                 >
                   취소
                 </Button>
@@ -66,7 +66,7 @@ const MyPage = () => {
                   variant='outlined'
                   color='gray'
                   className='ml-2 rounded-sm py-[11px] whitespace-nowrap hover:opacity-100'
-                  onClick={handleNickNameChage}
+                  onClick={handleNickNameChange}
                 >
                   변경하기
                 </Button>
@@ -76,7 +76,7 @@ const MyPage = () => {
                 variant='outlined'
                 color='gray'
                 className='ml-4 rounded-sm py-[11px] whitespace-nowrap'
-                onClick={handleNickNameChage}
+                onClick={handleNickNameChange}
               >
                 변경하기
               </Button>


### PR DESCRIPTION
## ⭐Key Changes
- 대표 닉네임 변경 API 연결했습니다.
- `처음 상태`는 인풋 비활성화 상태이고,
`변경하기 버튼 클릭 시` 인풋 활성화되며, 취소, 변경이 가능합니다.
`변경 시`에 유효성 검사 후 성공하면 닉네임 변경 완료 후 처음상태로 돌아가고,
유효성 검사가 실패하거나 에러가 발생하면 에러 메시지를 출력합니다.
`취소 시`에는 기존 닉네임으로 초기화되고 에러메시지도 없어지도록 하였습니다.

## 📌Issue
- Close #154 

## 🐾Next Move
- 부산대 인증
