### PR TITLE
부산대 인증 api 연결

### DIFF
--- a/src/apis/authApi.ts
+++ b/src/apis/authApi.ts
@@ -25,3 +25,11 @@ export const passwordChangeFn = ({ currentPassword, newPassword }: { currentPass
 export const getMyInfoFn = () => instance.get(`${ENDPOINT}/myinfo`).then(({ data }) => data.response);
 
 export const pnuMailAuthFn = ({ email }: { email: string }) => instance.post(`${ENDPOINT}/pusanuniv`, { email });
+
+export const pnuMailCertificationNumberCheckFn = ({
+  email,
+  certificationNumber,
+}: {
+  email: string;
+  certificationNumber: string;
+}) => instance.post(`${ENDPOINT}/pusanuniv/cert`, { email, certificationNumber });

--- a/src/apis/authApi.ts
+++ b/src/apis/authApi.ts
@@ -23,3 +23,5 @@ export const passwordChangeFn = ({ currentPassword, newPassword }: { currentPass
   instance.patch(`${ENDPOINT}/password/change`, { currentPassword, newPassword });
 
 export const getMyInfoFn = () => instance.get(`${ENDPOINT}/myinfo`).then(({ data }) => data.response);
+
+export const pnuMailAuthFn = ({ email }: { email: string }) => instance.post(`${ENDPOINT}/pusanuniv`, { email });

--- a/src/components/Home/OfficialGroup.tsx
+++ b/src/components/Home/OfficialGroup.tsx
@@ -8,7 +8,7 @@ const OfficialGroup = ({ officialGroups }: { officialGroups: Group[] }) => {
   return (
     <Carousel className='rounded-xl max-w-[768px]' loop>
       {officialGroups.map((group) => (
-        <Link to={`/${group.groupName}`} key={uuidv4()}>
+        <Link to={`/${group.groupId}/${group.groupName}`} key={uuidv4()}>
           <div key={group.groupId} className='relative h-full w-full'>
             <img src={group.groupImage} alt={group.groupName} className='w-full h-40 object-cover mx-auto' />
             <div className='absolute inset-0 grid h-full w-full place-items-center bg-black/50'>

--- a/src/components/JoinGroup/OfficialGroup.tsx
+++ b/src/components/JoinGroup/OfficialGroup.tsx
@@ -1,25 +1,69 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { Button, Input, Spinner } from '@material-tailwind/react';
 import DividerWithText from '@components/Common/DividerWithText';
-import { Button, Input } from '@material-tailwind/react';
+import { useMutation } from '@tanstack/react-query';
+import { pnuMailAuthFn } from '@apis/authApi';
+import { PNU_MAIL_PATTERN } from '@constants/validationPatterns';
+import { PNU_EMAIL_ERROR_MSG } from '@constants/errorMsg';
 
 const OfficialGroup = () => {
+  const [email, setEmail] = useState('');
+  const [emailErrorMsg, setEmailErrorMsg] = useState('');
+  const [isEmailSent, setIsEmailSent] = useState(false);
+
+  const { mutate: pnuMailAuth, isLoading: emailLoding } = useMutation({ mutationFn: pnuMailAuthFn });
+  const handleOnEmailChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setIsEmailSent(false);
+    setEmail(event.target.value);
+  };
+
+  const handleEmailSend = () => {
+    if (!PNU_MAIL_PATTERN.test(email)) {
+      setEmailErrorMsg(PNU_EMAIL_ERROR_MSG);
+      return;
+    }
+
+    setEmailErrorMsg('');
+    setIsEmailSent(false);
+    pnuMailAuth(
+      { email },
+      {
+        onSuccess: () => {
+          setIsEmailSent(true);
+        },
+      },
+    );
+  };
+
   return (
     <div className='w-full'>
       <section className='w-full text-center'>
         <DividerWithText>학교 인증을 진행해주세요.</DividerWithText>
-        <div className='relative flex w-full mt-6'>
-          <Input
-            type='text'
-            label='학교 이메일 입력'
-            className='pr-20'
-            containerProps={{
-              className: 'min-w-0',
-            }}
-            crossOrigin=''
-          />
-          <Button size='sm' className='!absolute right-1 top-1 rounded'>
-            인증번호 받기
-          </Button>
+        <div>
+          <div className='relative flex w-full mt-6'>
+            <Input
+              type='text'
+              label='학교 이메일 입력'
+              value={email}
+              onChange={handleOnEmailChange}
+              className='pr-20'
+              containerProps={{
+                className: 'min-w-0',
+              }}
+              crossOrigin=''
+            />
+            <Button
+              size='sm'
+              color={email ? 'gray' : 'blue-gray'}
+              disabled={!email}
+              className='!absolute right-1 top-1 rounded'
+              onClick={handleEmailSend}
+            >
+              {emailLoding ? <Spinner className='h-4 w-4' /> : <p>{isEmailSent ? '재전송' : '인증'}</p>}
+            </Button>
+          </div>
+          {emailErrorMsg && <p className='text-xs mt-1 mx-1 flex items-center text-error'>{emailErrorMsg}</p>}
+          {isEmailSent && <p className='text-xs mt-2'>인증번호를 전송했습니다.</p>}
         </div>
         <div className='relative flex w-full mt-6'>
           <Input

--- a/src/components/JoinGroup/OfficialGroup.tsx
+++ b/src/components/JoinGroup/OfficialGroup.tsx
@@ -2,20 +2,33 @@ import React, { useState } from 'react';
 import { Button, Input, Spinner } from '@material-tailwind/react';
 import DividerWithText from '@components/Common/DividerWithText';
 import { useMutation } from '@tanstack/react-query';
-import { pnuMailAuthFn } from '@apis/authApi';
+import { pnuMailAuthFn, pnuMailCertificationNumberCheckFn } from '@apis/authApi';
 import { PNU_MAIL_PATTERN } from '@constants/validationPatterns';
 import { PNU_EMAIL_ERROR_MSG } from '@constants/errorMsg';
+import { useNavigate } from 'react-router-dom';
+import { GroupDetail } from '@apis/dto';
+import { getErrorMsg } from '@utils/serverError';
 
-const OfficialGroup = () => {
+const OfficialGroup = ({ data }: { data: GroupDetail }) => {
+  const { groupId, groupName } = data;
+
   const [email, setEmail] = useState('');
   const [emailErrorMsg, setEmailErrorMsg] = useState('');
+  const [certificationNumberErrorMsg, setCertificationNumberErrorMsg] = useState('');
   const [isEmailSent, setIsEmailSent] = useState(false);
 
+  const [certificationNumber, setCertificationNumber] = useState('');
+
   const { mutate: pnuMailAuth, isLoading: emailLoding } = useMutation({ mutationFn: pnuMailAuthFn });
+  const { mutate: pnuMailCertificationNumberCheck } = useMutation({ mutationFn: pnuMailCertificationNumberCheckFn });
+  const navigate = useNavigate();
+
   const handleOnEmailChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setIsEmailSent(false);
     setEmail(event.target.value);
   };
+  const handleOnCertificationNumberChange = (event: React.ChangeEvent<HTMLInputElement>) =>
+    setCertificationNumber(event.target.value);
 
   const handleEmailSend = () => {
     if (!PNU_MAIL_PATTERN.test(email)) {
@@ -30,6 +43,25 @@ const OfficialGroup = () => {
       {
         onSuccess: () => {
           setIsEmailSent(true);
+        },
+      },
+    );
+  };
+
+  const handleEmailCheck = () => {
+    setCertificationNumberErrorMsg('');
+
+    pnuMailCertificationNumberCheck(
+      { email, certificationNumber },
+      {
+        onSuccess: () => {
+          navigate(`/${groupId}/${groupName}`, { replace: true });
+        },
+        onError: (error) => {
+          const errorMsg = getErrorMsg(error);
+          if (errorMsg) {
+            setCertificationNumberErrorMsg(errorMsg);
+          }
         },
       },
     );
@@ -65,20 +97,35 @@ const OfficialGroup = () => {
           {emailErrorMsg && <p className='text-xs mt-1 mx-1 flex items-center text-error'>{emailErrorMsg}</p>}
           {isEmailSent && <p className='text-xs mt-2'>인증번호를 전송했습니다.</p>}
         </div>
-        <div className='relative flex w-full mt-6'>
-          <Input
-            type='text'
-            label='인증번호 입력'
-            className='pr-20'
-            containerProps={{
-              className: 'min-w-0',
-            }}
-            crossOrigin=''
-          />
-          <Button size='sm' className='!absolute right-1 top-1 rounded'>
-            확인
-          </Button>
-        </div>
+        {isEmailSent && (
+          <div>
+            <div className='relative flex w-full mt-6'>
+              <Input
+                type='text'
+                label='인증번호 입력'
+                value={certificationNumber}
+                onChange={handleOnCertificationNumberChange}
+                className='pr-20'
+                containerProps={{
+                  className: 'min-w-0',
+                }}
+                crossOrigin=''
+              />
+              <Button
+                size='sm'
+                color={certificationNumber ? 'gray' : 'blue-gray'}
+                disabled={!certificationNumber}
+                onClick={handleEmailCheck}
+                className='!absolute right-1 top-1 rounded'
+              >
+                확인
+              </Button>
+            </div>
+            {certificationNumberErrorMsg && (
+              <p className='text-xs mt-1 mx-1 flex items-center text-error'>{certificationNumberErrorMsg}</p>
+            )}
+          </div>
+        )}
       </section>
     </div>
   );

--- a/src/constants/errorMsg.ts
+++ b/src/constants/errorMsg.ts
@@ -9,3 +9,5 @@ export const GROUP_NICKNAME_ERROR_MSG = '닉네임은 2자 이상 8자 이하의
 
 export const GROUP_PASSWORD_ERROR_MSG = '정답이 아닙니다.';
 export const GROUP_EXIST_NICKNAME_ERROR_MSG = '해당 닉네임은 이미 사용중입니다.';
+
+export const PNU_EMAIL_ERROR_MSG = '부산대 이메일이 아닙니다.';

--- a/src/constants/validationPatterns.ts
+++ b/src/constants/validationPatterns.ts
@@ -2,3 +2,4 @@ export const EMAIL_PATTERN = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/;
 export const PASSWORD_PATTERN = /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,20}$/;
 export const NAME_PATTERN = /^[가-힣a-zA-Z]{1,10}$/;
 export const GROUP_NICKNAME_PATTERN = /^[가-힣a-zA-Z0-9]{2,8}$/;
+export const PNU_MAIL_PATTERN = /[@]pusan\.ac\.kr$/;

--- a/src/pages/GroupJoinPage.tsx
+++ b/src/pages/GroupJoinPage.tsx
@@ -49,7 +49,7 @@ const GroupJoinPage = () => {
         </div>
         {groupType === 'un_official_opened_group' && <UnOfficialOpenedGroup data={data} />}
         {groupType === 'un_official_closed_group' && <UnOfficialClosedGroup data={data} />}
-        {groupType === 'official_group' && <OfficialGroup />}
+        {groupType === 'official_group' && <OfficialGroup data={data} />}
       </div>
     </section>
   );


### PR DESCRIPTION
## ⭐Key Changes

- 부산대 메일 인증, 인증번호 검증 API 연결하였습니다.
- 메일 전송중에 버튼에 Spinner 돌아가도록 처리하였습니다.
- 인증 코드까지 전송 완료되면 그룹 메인 페이지로 이동합니다.

## 📌Issue
- Close #137

## 👪To Reviewers
- 현재 API 서버주소 크램폴린 주소로 하면 정상 동작하지 않아, 이전 서버 주소로 테스트하며 진행하였는데 리뷰는 크램폴린 서버 해결된 후 확인하며 해주시는 게 좋을 것 같아요!


## 🐾Next Move
- 사용자 API 관련해서 가능한 건 다 처리한 상태라서 메타 태그 관련해서 작업해보겠습니다!