### PR TITLE
그룹초대링크 api연결

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 import { Outlet } from 'react-router-dom';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from '@material-tailwind/react';
-import Header from '@components/Header/Header';
-import Footer from '@components/Footer/Footer';
 import { queryClient } from '@apis/queryClient';
 import { useRecoilValue } from 'recoil';
 import tokenState from '@recoil/atoms/auth';
@@ -16,9 +14,7 @@ const App = () => {
   return (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider>
-        <Header />
         <Outlet />
-        <Footer />
       </ThemeProvider>
     </QueryClientProvider>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,23 +1,26 @@
 import React from 'react';
 import { Outlet } from 'react-router-dom';
-import { RecoilRoot } from 'recoil';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from '@material-tailwind/react';
 import Header from '@components/Header/Header';
 import Footer from '@components/Footer/Footer';
 import { queryClient } from '@apis/queryClient';
+import { useRecoilValue } from 'recoil';
+import tokenState from '@recoil/atoms/auth';
+import { instance } from '@apis/axios';
 
 const App = () => {
+  const token = useRecoilValue(tokenState);
+
+  instance.defaults.headers.common.Authorization = token;
   return (
-    <RecoilRoot>
-      <QueryClientProvider client={queryClient}>
-        <ThemeProvider>
-          <Header />
-          <Outlet />
-          <Footer />
-        </ThemeProvider>
-      </QueryClientProvider>
-    </RecoilRoot>
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider>
+        <Header />
+        <Outlet />
+        <Footer />
+      </ThemeProvider>
+    </QueryClientProvider>
   );
 };
 

--- a/src/apis/dto.ts
+++ b/src/apis/dto.ts
@@ -35,3 +35,8 @@ export interface ContributeItemProps {
   content: ContributeItemContent;
   createdAt: string;
 }
+
+export interface UnOfficialGroupProps {
+  data: GroupDetail;
+  onIsRegisteredAlertChange: () => void;
+}

--- a/src/apis/groupApi.ts
+++ b/src/apis/groupApi.ts
@@ -43,3 +43,6 @@ export const getMyContributeListFn = (groupId: number) =>
 
 export const getInviteCodeFn = (groupId: number) =>
   instance.get(`${ENDPOINT}/${groupId}/invitationLink`).then(({ data }) => data.response);
+
+export const checkInviteCodeFn = (inviteCode: string) =>
+  instance.get(`${ENDPOINT}/invitation/${inviteCode}`).then(({ data }) => data.response);

--- a/src/apis/groupApi.ts
+++ b/src/apis/groupApi.ts
@@ -40,3 +40,6 @@ export const setGroupMyInfoFn = ({ groupId, newGroupNickName }: { groupId: numbe
 
 export const getMyContributeListFn = (groupId: number) =>
   instance.get(`${ENDPOINT}/${groupId}/myInfo/myHistory`).then(({ data }) => data.response);
+
+export const getInviteCodeFn = (groupId: number) =>
+  instance.get(`${ENDPOINT}/${groupId}/invitationLink`).then(({ data }) => data.response);

--- a/src/apis/queryClient.ts
+++ b/src/apis/queryClient.ts
@@ -5,6 +5,7 @@ export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       retry: 0,
+      useErrorBoundary: true,
     },
   },
 });

--- a/src/components/Error/ErrorBoundary.tsx
+++ b/src/components/Error/ErrorBoundary.tsx
@@ -1,0 +1,42 @@
+import React, { ErrorInfo, ReactNode } from 'react';
+
+interface Props {
+  children?: ReactNode;
+  fallback: React.ElementType;
+}
+
+interface State {
+  hasError: boolean;
+  info: Error | null;
+}
+
+class ErrorBoundary extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      hasError: false,
+      info: null,
+    };
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    return { hasError: true, info: error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.log('error: ', error);
+    console.log('errorInfo: ', errorInfo);
+  }
+
+  render() {
+    const { hasError, info } = this.state;
+    const { children } = this.props;
+
+    if (hasError) {
+      return <this.props.fallback error={info} />;
+    }
+    return children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/components/Error/ErrorFallback.tsx
+++ b/src/components/Error/ErrorFallback.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Button, Typography } from '@material-tailwind/react';
+import { AxiosError } from 'axios';
+import { useNavigate } from 'react-router-dom';
+
+const getErrorMessage = (message: string) => {
+  switch (message) {
+    case '잘못된 접근입니다.':
+      return '존재하지 않는 초대링크입니다.';
+    case '이미 만료된 초대 링크입니다.':
+      return message;
+    default:
+      return message;
+  }
+};
+
+interface ErrorProps {
+  error: Error;
+}
+
+const ErrorFallback = ({ error }: ErrorProps) => {
+  const navigate = useNavigate();
+
+  if (error instanceof AxiosError) {
+    const errorData = error.response?.data.error;
+    const { status, message } = errorData;
+
+    if (status === 404) {
+      const errorMessage = getErrorMessage(message);
+      return (
+        <>
+          <Typography variant='h5'>{errorMessage}</Typography>
+          <Button onClick={() => navigate('/', { replace: true })}>홈으로</Button>
+        </>
+      );
+    }
+  }
+
+  return <div>asdf</div>;
+};
+
+export default ErrorFallback;

--- a/src/components/GroupCreate/GroupCreateCompleteSection.tsx
+++ b/src/components/GroupCreate/GroupCreateCompleteSection.tsx
@@ -14,6 +14,7 @@ interface GroupCreateCompleteSectionProps {
 
 const GroupCreateCompleteSection = ({ groupName }: GroupCreateCompleteSectionProps) => {
   const [isAlertOpen, setIsAlertOpen] = useState<boolean>(false);
+  const [isErrorAlertOpen, setIsErrorAlertOpen] = useState<boolean>(false);
   const [inviteCode, setInviteCode] = useState<string>('');
   const [groupId, setGroupId] = useState<number>(0);
   const groupInfo = useRecoilValue(groupCreateInfoState);
@@ -34,8 +35,9 @@ const GroupCreateCompleteSection = ({ groupName }: GroupCreateCompleteSectionPro
   const handleCopy = async () => {
     try {
       await navigator.clipboard.writeText(inviteCode);
-    } finally {
       setIsAlertOpen(true);
+    } catch {
+      setIsErrorAlertOpen(true);
     }
   };
   const handleStartClick = () => {
@@ -53,6 +55,14 @@ const GroupCreateCompleteSection = ({ groupName }: GroupCreateCompleteSectionPro
 
     return () => clearTimeout(timer);
   }, [isAlertOpen]);
+
+  useEffect(() => {
+    const timer: NodeJS.Timeout = setTimeout(() => {
+      setIsErrorAlertOpen(false);
+    }, 2000);
+
+    return () => clearTimeout(timer);
+  }, [isErrorAlertOpen]);
 
   return (
     <section className='space-y-10 max-w-xl'>
@@ -75,18 +85,26 @@ const GroupCreateCompleteSection = ({ groupName }: GroupCreateCompleteSectionPro
       <div className='flex justify-end'>
         <Button onClick={handleStartClick}>시작하기</Button>
       </div>
-      {isAlertOpen && (
-        <Alert
-          className='py-3 text-sm fixed top-10 z-30 max-w-xl min-w-max mx-auto bg-gray-200 text-gray-600'
-          open={isAlertOpen}
-          animate={{
-            mount: { y: 0 },
-            unmount: { y: 100 },
-          }}
-        >
-          초대코드가 복사되었습니다.
-        </Alert>
-      )}
+      <Alert
+        className='py-3 text-sm fixed top-10 z-30 max-w-xl min-w-max mx-auto bg-gray-200 text-gray-600'
+        open={isAlertOpen}
+        animate={{
+          mount: { y: 0 },
+          unmount: { y: 100 },
+        }}
+      >
+        초대코드가 복사되었습니다.
+      </Alert>
+      <Alert
+        className='py-3 text-sm fixed top-10 z-30 max-w-xl min-w-max mx-auto bg-gray-200 text-gray-600'
+        open={isErrorAlertOpen}
+        animate={{
+          mount: { y: 0 },
+          unmount: { y: 100 },
+        }}
+      >
+        죄송합니다. 다시 시도해주세요.
+      </Alert>
     </section>
   );
 };

--- a/src/components/GroupCreate/GroupCreateCompleteSection.tsx
+++ b/src/components/GroupCreate/GroupCreateCompleteSection.tsx
@@ -63,7 +63,7 @@ const GroupCreateCompleteSection = ({ groupName }: GroupCreateCompleteSectionPro
         <Typography variant='paragraph'>초대 링크를 통해 그룹원을 초대해보세요.</Typography>
       </div>
       <Input
-        className='truncate outline-none'
+        className='truncate outline-none cursor-pointer'
         label='초대 링크'
         value={inviteCode}
         size='lg'

--- a/src/components/GroupCreate/GroupCreateCompleteSection.tsx
+++ b/src/components/GroupCreate/GroupCreateCompleteSection.tsx
@@ -7,14 +7,15 @@ import { useRecoilValue } from 'recoil';
 import { groupCreateInfoState } from '@recoil/atoms/group';
 import { useMutation } from '@tanstack/react-query';
 import { createPageFn } from '@apis/pageApi';
+import useAlert from '@hooks/useAlert';
 
 interface GroupCreateCompleteSectionProps {
   groupName: string;
 }
 
 const GroupCreateCompleteSection = ({ groupName }: GroupCreateCompleteSectionProps) => {
-  const [isAlertOpen, setIsAlertOpen] = useState<boolean>(false);
-  const [isErrorAlertOpen, setIsErrorAlertOpen] = useState<boolean>(false);
+  const { isOpen: isAlertOpen, setIsOpen: setIsAlertOpen } = useAlert();
+  const { isOpen: isErrorAlertOpen, setIsOpen: setIsErrorAlertOpen } = useAlert();
   const [inviteCode, setInviteCode] = useState<string>('');
   const [groupId, setGroupId] = useState<number>(0);
   const groupInfo = useRecoilValue(groupCreateInfoState);
@@ -47,22 +48,6 @@ const GroupCreateCompleteSection = ({ groupName }: GroupCreateCompleteSectionPro
   useEffect(() => {
     createGroupMutate();
   }, []);
-
-  useEffect(() => {
-    const timer: NodeJS.Timeout = setTimeout(() => {
-      setIsAlertOpen(false);
-    }, 2000);
-
-    return () => clearTimeout(timer);
-  }, [isAlertOpen]);
-
-  useEffect(() => {
-    const timer: NodeJS.Timeout = setTimeout(() => {
-      setIsErrorAlertOpen(false);
-    }, 2000);
-
-    return () => clearTimeout(timer);
-  }, [isErrorAlertOpen]);
 
   return (
     <section className='space-y-10 max-w-xl'>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -4,7 +4,6 @@ import { MdPersonAdd, MdLogin } from 'react-icons/md';
 import tokenState from '@recoil/atoms/auth';
 import { ReactComponent as Logo } from '@assets/images/logo/logo.svg';
 import { Link } from 'react-router-dom';
-import { instance } from '@apis/axios';
 import HeaderMenu from './HeaderMenu';
 import SearchInput from '../Common/SearchInput';
 import GroupSelector from './GroupSelector';
@@ -12,8 +11,6 @@ import GroupSelector from './GroupSelector';
 const Header = () => {
   const token = useRecoilValue(tokenState);
   const isLoggedIn = Boolean(token);
-
-  instance.defaults.headers.common.Authorization = token;
 
   return (
     <header className='fixed top-0 flex justify-between items-center w-full px-2 py-2 border-b md:px-6 bg-white z-30'>

--- a/src/components/Header/HeaderMenu.tsx
+++ b/src/components/Header/HeaderMenu.tsx
@@ -4,7 +4,6 @@ import { MdMenu } from 'react-icons/md';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
 import tokenState from '@recoil/atoms/auth';
-import { inviteCodeDummyData } from '@dummy/group';
 import GroupMemberListModal from '@components/Modal/GroupMemberListModal';
 import InviteModal from '@components/Modal/InviteModal';
 import useModal from '@hooks/useModal';
@@ -43,13 +42,15 @@ const HeaderMenu = () => {
           <MenuItem onClick={handleLogout}>로그아웃</MenuItem>
         </MenuList>
       </Menu>
-      <InviteModal code={inviteCodeDummyData} isOpen={inviteModal.isOpen} onModalClick={inviteModal.handleModal} />
       {groupId && (
-        <GroupMemberListModal
-          isOpen={groupMemberListModal.isOpen}
-          handleModal={groupMemberListModal.handleModal}
-          groupId={groupId}
-        />
+        <>
+          <InviteModal isOpen={inviteModal.isOpen} onModalClick={inviteModal.handleModal} groupId={groupId} />
+          <GroupMemberListModal
+            isOpen={groupMemberListModal.isOpen}
+            handleModal={groupMemberListModal.handleModal}
+            groupId={groupId}
+          />
+        </>
       )}
     </>
   );

--- a/src/components/Invite/InviteFetcher.tsx
+++ b/src/components/Invite/InviteFetcher.tsx
@@ -3,7 +3,7 @@ import { checkInviteCodeFn } from '@apis/groupApi';
 import { GROUP_KEYS } from '@constants/queryKeys';
 import { Spinner, Typography } from '@material-tailwind/react';
 import { useQuery } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import tokenState from '@recoil/atoms/auth';
 
@@ -13,6 +13,7 @@ interface InviteFetcherProps {
 
 const InviteFetcher = ({ inviteCode }: InviteFetcherProps) => {
   const navigate = useNavigate();
+  const location = useLocation();
   const token = useRecoilValue(tokenState);
   const { data, isLoading } = useQuery({
     queryKey: GROUP_KEYS.checkGroupInviteCode({ inviteCode }),
@@ -25,7 +26,7 @@ const InviteFetcher = ({ inviteCode }: InviteFetcherProps) => {
       if (token) {
         navigate(`/${groupId}/join`, { replace: true });
       } else {
-        navigate('/login', { replace: true });
+        navigate('/login', { replace: true, state: { path: location.pathname } });
       }
     }
   }, [isLoading, data, navigate]);

--- a/src/components/Invite/InviteFetcher.tsx
+++ b/src/components/Invite/InviteFetcher.tsx
@@ -1,9 +1,11 @@
+import React, { useEffect } from 'react';
 import { checkInviteCodeFn } from '@apis/groupApi';
 import { GROUP_KEYS } from '@constants/queryKeys';
 import { Spinner, Typography } from '@material-tailwind/react';
 import { useQuery } from '@tanstack/react-query';
-import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+import tokenState from '@recoil/atoms/auth';
 
 interface InviteFetcherProps {
   inviteCode: string;
@@ -11,15 +13,27 @@ interface InviteFetcherProps {
 
 const InviteFetcher = ({ inviteCode }: InviteFetcherProps) => {
   const navigate = useNavigate();
-  const { data } = useQuery({
+  const token = useRecoilValue(tokenState);
+  const { data, isLoading } = useQuery({
     queryKey: GROUP_KEYS.checkGroupInviteCode({ inviteCode }),
     queryFn: () => checkInviteCodeFn(inviteCode),
   });
 
-  if (data) {
-    const { groupId } = data;
-    navigate(`/${groupId}/join`, { replace: true });
+  useEffect(() => {
+    if (!isLoading && data) {
+      const { groupId } = data;
+      if (token) {
+        navigate(`/${groupId}/join`, { replace: true });
+      } else {
+        navigate('/login');
+      }
+    }
+  }, [isLoading, data, navigate]);
+
+  if (isLoading) {
+    return <div>Loading...</div>;
   }
+
   return (
     <>
       <Typography variant='h5'>잠시만 기다려주세요.</Typography>

--- a/src/components/Invite/InviteFetcher.tsx
+++ b/src/components/Invite/InviteFetcher.tsx
@@ -25,7 +25,7 @@ const InviteFetcher = ({ inviteCode }: InviteFetcherProps) => {
       if (token) {
         navigate(`/${groupId}/join`, { replace: true });
       } else {
-        navigate('/login');
+        navigate('/login', { replace: true });
       }
     }
   }, [isLoading, data, navigate]);

--- a/src/components/Invite/InviteFetcher.tsx
+++ b/src/components/Invite/InviteFetcher.tsx
@@ -1,0 +1,31 @@
+import { checkInviteCodeFn } from '@apis/groupApi';
+import { GROUP_KEYS } from '@constants/queryKeys';
+import { Spinner, Typography } from '@material-tailwind/react';
+import { useQuery } from '@tanstack/react-query';
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+interface InviteFetcherProps {
+  inviteCode: string;
+}
+
+const InviteFetcher = ({ inviteCode }: InviteFetcherProps) => {
+  const navigate = useNavigate();
+  const { data } = useQuery({
+    queryKey: GROUP_KEYS.checkGroupInviteCode({ inviteCode }),
+    queryFn: () => checkInviteCodeFn(inviteCode),
+  });
+
+  if (data) {
+    const { groupId } = data;
+    navigate(`/${groupId}/join`, { replace: true });
+  }
+  return (
+    <>
+      <Typography variant='h5'>잠시만 기다려주세요.</Typography>
+      <Spinner className='h-12 w-12' />
+    </>
+  );
+};
+
+export default InviteFetcher;

--- a/src/components/JoinGroup/UnOfficialClosedGroup.tsx
+++ b/src/components/JoinGroup/UnOfficialClosedGroup.tsx
@@ -54,7 +54,6 @@ const UnOfficialClosedGroup = ({ data, onIsRegisteredAlertChange }: UnOfficialCl
               );
               break;
             case '이미 가입된 회원입니다.':
-              console.log('asdf');
               onIsRegisteredAlertChange();
               break;
             default:

--- a/src/components/JoinGroup/UnOfficialClosedGroup.tsx
+++ b/src/components/JoinGroup/UnOfficialClosedGroup.tsx
@@ -1,60 +1,78 @@
 import React from 'react';
 import { Button, Input } from '@material-tailwind/react';
 import { FieldValues, SubmitHandler, useForm } from 'react-hook-form';
-import { GROUP_EXIST_NICKNAME_ERROR_MSG } from '@constants/errorMsg';
-import { useMutation } from '@tanstack/react-query';
-import { joinGroupFn } from '@apis/groupApi';
-import { GroupDetail } from '@apis/dto';
-import { useNavigate } from 'react-router-dom';
-import { AxiosError } from 'axios';
+import { UnOfficialGroupProps } from '@apis/dto';
 import { nickNameRegister } from '@utils/Form/nickName';
+import useJoinMutation from '@hooks/useJoinMutation';
+import {
+  GROUP_INVITE_CODE_ERROR_MSG,
+  GROUP_INVITE_CODE_EXPIRED_ERROR_MSG,
+  REQUIRE_ERROR_MSG,
+} from '@constants/errorMsg';
+import { useMutation } from '@tanstack/react-query';
+import { checkInviteCodeFn } from '@apis/groupApi';
+import { AxiosError } from 'axios';
 
-interface UnOfficialClosedGroupProps {
-  data: GroupDetail;
-  onIsRegisteredAlertChange: () => void;
-}
-interface NickNameInput {
+interface ClosedGroupInput {
   nickName: string;
+  inviteCode: string;
 }
 
-const UnOfficialClosedGroup = ({ data, onIsRegisteredAlertChange }: UnOfficialClosedGroupProps) => {
-  const navigate = useNavigate();
+const UnOfficialClosedGroup = ({ data, onIsRegisteredAlertChange }: UnOfficialGroupProps) => {
   const { groupId, groupName } = data;
   const {
     register,
     handleSubmit,
     setError,
+    getValues,
     formState: { errors, isValid },
-  } = useForm<NickNameInput>({
+  } = useForm<ClosedGroupInput>({
     defaultValues: {
       nickName: '',
+      inviteCode: '',
     },
   });
-  const { mutate: joinGroup } = useMutation({
-    mutationFn: (nickName: string) => joinGroupFn({ groupId, nickName }),
+  const { mutate: joinGroup } = useJoinMutation({
+    groupId,
+    groupName,
+    nickName: getValues('nickName'),
+    setError,
+    onIsRegisteredAlertChange,
+  });
+  const { mutate: checkInviteCode } = useMutation({
+    mutationFn: checkInviteCodeFn,
     onSuccess: () => {
-      navigate(`/${groupId}/${groupName}`, { replace: true });
+      joinGroup();
     },
     onError: (error) => {
       if (error instanceof AxiosError) {
         const errorData = error.response?.data.error;
         const { message, status } = errorData;
-        if (status === 400) {
+        if (status === 404) {
           switch (message) {
-            case '해당 닉네임은 이미 사용중입니다.':
+            case '잘못된 접근입니다.':
               setError(
-                'nickName',
+                'inviteCode',
                 {
-                  type: 'exist',
-                  message: GROUP_EXIST_NICKNAME_ERROR_MSG,
+                  type: 'wrong',
+                  message: GROUP_INVITE_CODE_ERROR_MSG,
                 },
                 {
                   shouldFocus: true,
                 },
               );
               break;
-            case '이미 가입된 회원입니다.':
-              onIsRegisteredAlertChange();
+            case '이미 만료된 초대 링크입니다.':
+              setError(
+                'inviteCode',
+                {
+                  type: 'expired',
+                  message: GROUP_INVITE_CODE_EXPIRED_ERROR_MSG,
+                },
+                {
+                  shouldFocus: true,
+                },
+              );
               break;
             default:
               break;
@@ -63,19 +81,17 @@ const UnOfficialClosedGroup = ({ data, onIsRegisteredAlertChange }: UnOfficialCl
       }
     },
   });
-
-  const handleJoin: SubmitHandler<FieldValues> = ({ nickName }) => {
+  const handleJoin: SubmitHandler<FieldValues> = ({ inviteCode }) => {
     if (!isValid) return;
 
-    joinGroup(nickName);
+    checkInviteCode(inviteCode);
   };
   return (
     <form className='flex flex-col gap-4 w-full' onSubmit={handleSubmit(handleJoin)}>
-      <div>
+      <div className='w-full'>
         <Input
           type='text'
           label='닉네임'
-          className=''
           containerProps={{
             className: 'min-w-0 w-full',
           }}
@@ -83,6 +99,22 @@ const UnOfficialClosedGroup = ({ data, onIsRegisteredAlertChange }: UnOfficialCl
           {...register('nickName', nickNameRegister)}
         />
         {errors.nickName && <p className='text-xs mt-1 mx-1 flex items-center text-error'>{errors.nickName.message}</p>}
+      </div>
+      <div className='w-full'>
+        <Input
+          type='text'
+          label='초대코드 입력'
+          containerProps={{
+            className: 'min-w-0 w-full',
+          }}
+          crossOrigin=''
+          {...register('inviteCode', {
+            required: REQUIRE_ERROR_MSG,
+          })}
+        />
+        {errors.inviteCode && (
+          <p className='text-xs mt-1 mx-1 flex items-center text-error'>{errors.inviteCode.message}</p>
+        )}
       </div>
       <Button type='submit'>가입하기</Button>
     </form>

--- a/src/components/JoinGroup/UnOfficialClosedGroup.tsx
+++ b/src/components/JoinGroup/UnOfficialClosedGroup.tsx
@@ -9,11 +9,15 @@ import { useNavigate } from 'react-router-dom';
 import { AxiosError } from 'axios';
 import { nickNameRegister } from '@utils/Form/nickName';
 
+interface UnOfficialClosedGroupProps {
+  data: GroupDetail;
+  onIsRegisteredAlertChange: () => void;
+}
 interface NickNameInput {
   nickName: string;
 }
 
-const UnOfficialClosedGroup = ({ data }: { data: GroupDetail }) => {
+const UnOfficialClosedGroup = ({ data, onIsRegisteredAlertChange }: UnOfficialClosedGroupProps) => {
   const navigate = useNavigate();
   const { groupId, groupName } = data;
   const {
@@ -35,17 +39,27 @@ const UnOfficialClosedGroup = ({ data }: { data: GroupDetail }) => {
       if (error instanceof AxiosError) {
         const errorData = error.response?.data.error;
         const { message, status } = errorData;
-        if (status === 400 && message === '해당 닉네임은 이미 사용중입니다.') {
-          setError(
-            'nickName',
-            {
-              type: 'exist',
-              message: GROUP_EXIST_NICKNAME_ERROR_MSG,
-            },
-            {
-              shouldFocus: true,
-            },
-          );
+        if (status === 400) {
+          switch (message) {
+            case '해당 닉네임은 이미 사용중입니다.':
+              setError(
+                'nickName',
+                {
+                  type: 'exist',
+                  message: GROUP_EXIST_NICKNAME_ERROR_MSG,
+                },
+                {
+                  shouldFocus: true,
+                },
+              );
+              break;
+            case '이미 가입된 회원입니다.':
+              console.log('asdf');
+              onIsRegisteredAlertChange();
+              break;
+            default:
+              break;
+          }
         }
       }
     },

--- a/src/components/JoinGroup/UnOfficialOpenedGroup.tsx
+++ b/src/components/JoinGroup/UnOfficialOpenedGroup.tsx
@@ -10,12 +10,17 @@ import { checkGroupPasswordFn, joinGroupFn } from '@apis/groupApi';
 import { AxiosError } from 'axios';
 import { nickNameRegister } from '@utils/Form/nickName';
 
+interface UnOfficialOpenedGroupProps {
+  data: GroupDetail;
+  onIsRegisteredAlertChange: () => void;
+}
+
 interface OpenedGroupInput {
   nickName: string;
   entrancePassword: string;
 }
 
-const UnOfficialOpenedGroup = ({ data }: { data: GroupDetail }) => {
+const UnOfficialOpenedGroup = ({ data, onIsRegisteredAlertChange }: UnOfficialOpenedGroupProps) => {
   const navigate = useNavigate();
   const { groupId, groupName, entranceHint } = data;
   const {
@@ -39,17 +44,27 @@ const UnOfficialOpenedGroup = ({ data }: { data: GroupDetail }) => {
       if (error instanceof AxiosError) {
         const errorData = error.response?.data.error;
         const { message, status } = errorData;
-        if (status === 400 && message === '해당 닉네임은 이미 사용중입니다.') {
-          setError(
-            'nickName',
-            {
-              type: 'exist',
-              message: GROUP_EXIST_NICKNAME_ERROR_MSG,
-            },
-            {
-              shouldFocus: true,
-            },
-          );
+        if (status === 400) {
+          switch (message) {
+            case '해당 닉네임은 이미 사용중입니다.':
+              setError(
+                'nickName',
+                {
+                  type: 'exist',
+                  message: GROUP_EXIST_NICKNAME_ERROR_MSG,
+                },
+                {
+                  shouldFocus: true,
+                },
+              );
+              break;
+            case '이미 가입된 회원입니다.':
+              console.log('asdf');
+              onIsRegisteredAlertChange();
+              break;
+            default:
+              break;
+          }
         }
       }
     },

--- a/src/components/JoinGroup/UnOfficialOpenedGroup.tsx
+++ b/src/components/JoinGroup/UnOfficialOpenedGroup.tsx
@@ -59,7 +59,6 @@ const UnOfficialOpenedGroup = ({ data, onIsRegisteredAlertChange }: UnOfficialOp
               );
               break;
             case '이미 가입된 회원입니다.':
-              console.log('asdf');
               onIsRegisteredAlertChange();
               break;
             default:

--- a/src/components/Layout/MainLayout.tsx
+++ b/src/components/Layout/MainLayout.tsx
@@ -1,11 +1,17 @@
 import React from 'react';
 import { Outlet } from 'react-router-dom';
+import Footer from '@components/Footer/Footer';
+import Header from '@components/Header/Header';
 
 const MainLayout = () => {
   return (
-    <div className='max-w-3xl min-w-max mx-auto mt-[59px] pt-20 pb-12'>
-      <Outlet />
-    </div>
+    <>
+      <Header />
+      <div className='max-w-3xl min-w-max mx-auto mt-[59px] pt-20 pb-12'>
+        <Outlet />
+      </div>
+      <Footer />
+    </>
   );
 };
 

--- a/src/components/Layout/NoHeaderLayout.tsx
+++ b/src/components/Layout/NoHeaderLayout.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+
+const NoHeaderLayout = () => {
+  return (
+    <div className='max-w-3xl min-w-max mx-auto mt-[59px] pt-20 pb-12'>
+      <Outlet />
+    </div>
+  );
+};
+
+export default NoHeaderLayout;

--- a/src/components/Layout/PageLayout.tsx
+++ b/src/components/Layout/PageLayout.tsx
@@ -1,11 +1,17 @@
 import React from 'react';
 import { Outlet } from 'react-router-dom';
+import Footer from '@components/Footer/Footer';
+import Header from '@components/Header/Header';
 
 const PageLayout = () => {
   return (
-    <div className='relative 2xl:mx-20 mt-[59px] pt-20 pb-12'>
-      <Outlet />
-    </div>
+    <>
+      <Header />
+      <div className='relative 2xl:mx-20 mt-[59px] pt-20 pb-12'>
+        <Outlet />
+      </div>
+      <Footer />
+    </>
   );
 };
 

--- a/src/components/Modal/InviteModal.tsx
+++ b/src/components/Modal/InviteModal.tsx
@@ -1,19 +1,27 @@
 import React, { useEffect, useState } from 'react';
-import { Button, Dialog, DialogHeader, DialogBody, DialogFooter, Alert } from '@material-tailwind/react';
+import { Button, Dialog, DialogHeader, DialogBody, DialogFooter, Alert, Input } from '@material-tailwind/react';
 import { MdContentCopy, MdClear } from 'react-icons/md';
+import { useQuery } from '@tanstack/react-query';
+import { GROUP_KEYS } from '@constants/queryKeys';
+import { getInviteCodeFn } from '@apis/groupApi';
 
 interface InviteModalProps {
-  code: string;
   isOpen: boolean;
   onModalClick: () => void;
+  groupId: string;
 }
 
-const InviteModal = ({ code, isOpen, onModalClick }: InviteModalProps) => {
+const InviteModal = ({ isOpen, onModalClick, groupId }: InviteModalProps) => {
+  const numGroupId = Number(groupId);
   const [isAlertOpen, setIsAlertOpen] = useState<boolean>(false);
+  const { data } = useQuery({
+    queryKey: GROUP_KEYS.groupInviteCode({ groupId: numGroupId }),
+    queryFn: () => getInviteCodeFn(numGroupId),
+  });
 
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(code);
+      await navigator.clipboard.writeText(data?.inviteCode);
     } finally {
       setIsAlertOpen(true);
     }
@@ -37,13 +45,16 @@ const InviteModal = ({ code, isOpen, onModalClick }: InviteModalProps) => {
         <p className='text-sm text-gray-600 font-normal'>클릭하여 링크 복사</p>
       </DialogHeader>
       <DialogBody className='flex'>
-        <p className='px-4 py-1 bg-blue-gray-50 text-black overflow-auto'>{code}</p>
-        <Button
-          className='bg-blue-gray-50 text-xl text-black rounded-none shadow-none hover:shadow-none'
+        <Input
+          className='truncate outline-none cursor-pointer'
+          label='초대 링크'
+          value={data?.inviteCode}
+          size='lg'
+          readOnly
+          crossOrigin=''
+          icon={<MdContentCopy onClick={handleCopy} />}
           onClick={handleCopy}
-        >
-          <MdContentCopy />
-        </Button>
+        />
       </DialogBody>
       <DialogFooter>
         {isAlertOpen ? (

--- a/src/components/Modal/InviteModal.tsx
+++ b/src/components/Modal/InviteModal.tsx
@@ -14,6 +14,7 @@ interface InviteModalProps {
 const InviteModal = ({ isOpen, onModalClick, groupId }: InviteModalProps) => {
   const numGroupId = Number(groupId);
   const [isAlertOpen, setIsAlertOpen] = useState<boolean>(false);
+  const [isErrorAlertOpen, setIsErrorAlertOpen] = useState<boolean>(false);
   const { data } = useQuery({
     queryKey: GROUP_KEYS.groupInviteCode({ groupId: numGroupId }),
     queryFn: () => getInviteCodeFn(numGroupId),
@@ -22,8 +23,9 @@ const InviteModal = ({ isOpen, onModalClick, groupId }: InviteModalProps) => {
   const handleCopy = async () => {
     try {
       await navigator.clipboard.writeText(data?.inviteCode);
-    } finally {
       setIsAlertOpen(true);
+    } catch {
+      setIsErrorAlertOpen(true);
     }
   };
 
@@ -34,6 +36,14 @@ const InviteModal = ({ isOpen, onModalClick, groupId }: InviteModalProps) => {
 
     return () => clearTimeout(timer);
   }, [isAlertOpen]);
+
+  useEffect(() => {
+    const timer: NodeJS.Timeout = setTimeout(() => {
+      setIsErrorAlertOpen(false);
+    }, 2000);
+
+    return () => clearTimeout(timer);
+  }, [isErrorAlertOpen]);
 
   return (
     <Dialog open={isOpen} handler={onModalClick}>
@@ -57,19 +67,31 @@ const InviteModal = ({ isOpen, onModalClick, groupId }: InviteModalProps) => {
         />
       </DialogBody>
       <DialogFooter>
-        {isAlertOpen ? (
-          <Alert
-            className='py-3 font-semibold'
-            open={isAlertOpen}
-            animate={{
-              mount: { y: 0 },
-              unmount: { y: 100 },
-            }}
-          >
-            초대코드가 복사되었습니다.
-          </Alert>
+        {isAlertOpen || isErrorAlertOpen ? (
+          <>
+            <Alert
+              className='py-3 font-semibold'
+              open={isAlertOpen}
+              animate={{
+                mount: { y: 0 },
+                unmount: { y: 100 },
+              }}
+            >
+              초대코드가 복사되었습니다.
+            </Alert>
+            <Alert
+              className='py-3 font-semibold'
+              open={isErrorAlertOpen}
+              animate={{
+                mount: { y: 0 },
+                unmount: { y: 100 },
+              }}
+            >
+              죄송합니다. 다시 시도해주세요.
+            </Alert>
+          </>
         ) : (
-          <Button variant='filled' ripple={false} onClick={onModalClick}>
+          <Button variant='filled' className='h-12' ripple={false} onClick={onModalClick}>
             확인
           </Button>
         )}

--- a/src/components/Modal/InviteModal.tsx
+++ b/src/components/Modal/InviteModal.tsx
@@ -1,9 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { Button, Dialog, DialogHeader, DialogBody, DialogFooter, Alert, Input } from '@material-tailwind/react';
 import { MdContentCopy, MdClear } from 'react-icons/md';
 import { useQuery } from '@tanstack/react-query';
 import { GROUP_KEYS } from '@constants/queryKeys';
 import { getInviteCodeFn } from '@apis/groupApi';
+import useAlert from '@hooks/useAlert';
 
 interface InviteModalProps {
   isOpen: boolean;
@@ -13,8 +14,8 @@ interface InviteModalProps {
 
 const InviteModal = ({ isOpen, onModalClick, groupId }: InviteModalProps) => {
   const numGroupId = Number(groupId);
-  const [isAlertOpen, setIsAlertOpen] = useState<boolean>(false);
-  const [isErrorAlertOpen, setIsErrorAlertOpen] = useState<boolean>(false);
+  const { isOpen: isAlertOpen, setIsOpen: setIsAlertOpen } = useAlert();
+  const { isOpen: isErrorAlertOpen, setIsOpen: setIsErrorAlertOpen } = useAlert();
   const { data } = useQuery({
     queryKey: GROUP_KEYS.groupInviteCode({ groupId: numGroupId }),
     queryFn: () => getInviteCodeFn(numGroupId),
@@ -28,22 +29,6 @@ const InviteModal = ({ isOpen, onModalClick, groupId }: InviteModalProps) => {
       setIsErrorAlertOpen(true);
     }
   };
-
-  useEffect(() => {
-    const timer: NodeJS.Timeout = setTimeout(() => {
-      setIsAlertOpen(false);
-    }, 2000);
-
-    return () => clearTimeout(timer);
-  }, [isAlertOpen]);
-
-  useEffect(() => {
-    const timer: NodeJS.Timeout = setTimeout(() => {
-      setIsErrorAlertOpen(false);
-    }, 2000);
-
-    return () => clearTimeout(timer);
-  }, [isErrorAlertOpen]);
 
   return (
     <Dialog open={isOpen} handler={onModalClick}>

--- a/src/constants/errorMsg.ts
+++ b/src/constants/errorMsg.ts
@@ -10,3 +10,6 @@ export const GROUP_NICKNAME_ERROR_MSG = '닉네임은 2자 이상 8자 이하의
 export const GROUP_PASSWORD_ERROR_MSG = '정답이 아닙니다.';
 export const GROUP_EXIST_NICKNAME_ERROR_MSG = '해당 닉네임은 이미 사용중입니다.';
 export const GROUP_SAME_NICKNAME_ERROR_MSG = '기존 닉네임과 같은 닉네임입니다.';
+
+export const GROUP_INVITE_CODE_ERROR_MSG = '잘못된 초대링크입니다.';
+export const GROUP_INVITE_CODE_EXPIRED_ERROR_MSG = '만료된 초대링크입니다.';

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -18,6 +18,7 @@ export const GROUP_KEYS = {
   groupMyInfo: ({ groupId }: { groupId: number }) => ['groupMyInfo', groupId] as const,
   myContributeList: ({ groupId }: { groupId: number }) => ['myContributeList', groupId] as const,
   groupInviteCode: ({ groupId }: { groupId: number }) => ['inviteCode', groupId] as const,
+  checkGroupInviteCode: ({ inviteCode }: { inviteCode: string }) => ['inviteCode', inviteCode] as const,
 };
 
 export const AUTH_KEYS = {

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -17,6 +17,7 @@ export const GROUP_KEYS = {
   members: ({ groupId }: { groupId: number }) => ['members', groupId] as const,
   groupMyInfo: ({ groupId }: { groupId: number }) => ['groupMyInfo', groupId] as const,
   myContributeList: ({ groupId }: { groupId: number }) => ['myContributeList', groupId] as const,
+  groupInviteCode: ({ groupId }: { groupId: number }) => ['inviteCode', groupId] as const,
 };
 
 export const AUTH_KEYS = {

--- a/src/hooks/useAlert.ts
+++ b/src/hooks/useAlert.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react';
+
+const useAlert = () => {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  useEffect(() => {
+    const timer: NodeJS.Timeout = setTimeout(() => {
+      setIsOpen(false);
+    }, 3000);
+
+    return () => clearTimeout(timer);
+  }, [isOpen]);
+
+  return { isOpen, setIsOpen };
+};
+
+export default useAlert;

--- a/src/hooks/useJoinMutation.ts
+++ b/src/hooks/useJoinMutation.ts
@@ -1,0 +1,58 @@
+import { AxiosError } from 'axios';
+import { useMutation } from '@tanstack/react-query';
+import { UseFormSetError } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+import { joinGroupFn } from '@apis/groupApi';
+import { GROUP_EXIST_NICKNAME_ERROR_MSG } from '@constants/errorMsg';
+
+interface NickNameInput {
+  nickName: string;
+}
+
+interface UseJoinMutation {
+  groupId: number;
+  groupName: string;
+  nickName: string;
+  setError: UseFormSetError<NickNameInput>;
+  onIsRegisteredAlertChange: () => void;
+}
+
+const useJoinMutation = ({ groupId, groupName, nickName, setError, onIsRegisteredAlertChange }: UseJoinMutation) => {
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: () => joinGroupFn({ groupId, nickName }),
+    onSuccess: () => {
+      navigate(`/${groupId}/${groupName}`, { replace: true });
+    },
+    onError: (error) => {
+      if (error instanceof AxiosError) {
+        const errorData = error.response?.data.error;
+        const { message, status } = errorData;
+        if (status === 400) {
+          switch (message) {
+            case '해당 닉네임은 이미 사용중입니다.':
+              setError(
+                'nickName',
+                {
+                  type: 'exist',
+                  message: GROUP_EXIST_NICKNAME_ERROR_MSG,
+                },
+                {
+                  shouldFocus: true,
+                },
+              );
+              break;
+            case '이미 가입된 회원입니다.':
+              onIsRegisteredAlertChange();
+              break;
+            default:
+              break;
+          }
+        }
+      }
+    },
+  });
+};
+
+export default useJoinMutation;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { RecoilRoot } from 'recoil';
 
 import './tailwind.css';
 
@@ -19,12 +20,12 @@ import PostEditPage from '@pages/PostEditPage';
 import PostHistoryPage from '@pages/PostHistoryPage';
 import GroupJoinPage from '@pages/GroupJoinPage';
 import KakaoLoginPage from '@pages/KakaoLoginPage';
-
 import NotFoundPage from '@pages/NotFoundPage';
+import InviteProcessPage from '@pages/InviteProcessPage';
 
 import MainLayout from '@components/Layout/MainLayout';
 import PageLayout from '@components/Layout/PageLayout';
-import { RecoilRoot } from 'recoil';
+import NoHeaderLayout from '@components/Layout/NoHeaderLayout';
 import App from './App';
 
 const router = createBrowserRouter([
@@ -64,10 +65,6 @@ const router = createBrowserRouter([
             element: <GroupCreatePage />,
           },
           {
-            path: '/:groupId/join',
-            element: <GroupJoinPage />,
-          },
-          {
             path: '/:groupId/myPage',
             element: <GroupMyPage />,
           },
@@ -103,6 +100,19 @@ const router = createBrowserRouter([
           {
             path: '/:groupId/:page/:postId/edit',
             element: <PostEditPage />,
+          },
+        ],
+      },
+      {
+        element: <NoHeaderLayout />,
+        children: [
+          {
+            path: '/:groupId/join',
+            element: <GroupJoinPage />,
+          },
+          {
+            path: '/invite/:inviteCode',
+            element: <InviteProcessPage />,
           },
         ],
       },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,6 +24,7 @@ import NotFoundPage from '@pages/NotFoundPage';
 
 import MainLayout from '@components/Layout/MainLayout';
 import PageLayout from '@components/Layout/PageLayout';
+import { RecoilRoot } from 'recoil';
 import App from './App';
 
 const router = createBrowserRouter([
@@ -112,6 +113,8 @@ const router = createBrowserRouter([
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
   // <React.StrictMode>
-  <RouterProvider router={router} />,
+  <RecoilRoot>
+    <RouterProvider router={router} />
+  </RecoilRoot>,
   // </React.StrictMode>,
 );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -41,18 +41,6 @@ const router = createBrowserRouter([
             element: <HomePage />,
           },
           {
-            path: '/signUp',
-            element: <SignUpPage />,
-          },
-          {
-            path: '/kakaoLogin',
-            element: <KakaoLoginPage />,
-          },
-          {
-            path: '/login',
-            element: <LoginPage />,
-          },
-          {
             path: '/myPage',
             element: <MyPage />,
           },
@@ -106,6 +94,18 @@ const router = createBrowserRouter([
       {
         element: <NoHeaderLayout />,
         children: [
+          {
+            path: '/signUp',
+            element: <SignUpPage />,
+          },
+          {
+            path: '/kakaoLogin',
+            element: <KakaoLoginPage />,
+          },
+          {
+            path: '/login',
+            element: <LoginPage />,
+          },
           {
             path: '/:groupId/join',
             element: <GroupJoinPage />,

--- a/src/pages/GroupJoinPage.tsx
+++ b/src/pages/GroupJoinPage.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react';
-import { useParams } from 'react-router-dom';
+import React, { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import { Typography } from '@material-tailwind/react';
+import { Alert, Button, Typography } from '@material-tailwind/react';
 import { GROUP_KEYS } from '@constants/queryKeys';
 import { getGroupInfoFn } from '@apis/groupApi';
 import Logo from '@assets/images/logo/logo.svg';
@@ -10,9 +10,11 @@ import UnOfficialOpenedGroup from '@components/JoinGroup/UnOfficialOpenedGroup';
 import UnOfficialClosedGroup from '@components/JoinGroup/UnOfficialClosedGroup';
 
 const GroupJoinPage = () => {
+  const navigate = useNavigate();
   const { groupId } = useParams();
   const numGroupId = Number(groupId);
-  const [isImgError, setImageError] = useState(false);
+  const [isImgError, setImageError] = useState<boolean>(false);
+  const [isRegisteredAlertOpen, setIsRegisteredAlertOpen] = useState<boolean>(false);
   const { data, isLoading } = useQuery({
     queryKey: GROUP_KEYS.groupInfo({ groupId: numGroupId }),
     queryFn: () => getGroupInfoFn(numGroupId),
@@ -22,6 +24,17 @@ const GroupJoinPage = () => {
     e.currentTarget.src = Logo;
     setImageError(true);
   };
+  const handleIsRegisteredAlertOpen = () => {
+    setIsRegisteredAlertOpen((prev) => !prev);
+  };
+
+  useEffect(() => {
+    const timer: NodeJS.Timeout = setTimeout(() => {
+      setIsRegisteredAlertOpen(false);
+    }, 2000);
+
+    return () => clearTimeout(timer);
+  }, [isRegisteredAlertOpen]);
 
   if (isLoading) {
     return <div>Loading...</div>;
@@ -29,6 +42,25 @@ const GroupJoinPage = () => {
   const { groupName, groupImage, introduction, groupType, created_at: createdAt, memberCount } = data;
   return (
     <section className='max-w-fit mx-auto'>
+      <Alert
+        className='flex justify-between items-center py-3 font-semibold'
+        open={isRegisteredAlertOpen}
+        action={
+          <Button
+            variant='text'
+            className='p-1 text-white text-xs'
+            onClick={() => navigate(`/${groupId}/${data.groupName}`)}
+          >
+            메인페이지로
+          </Button>
+        }
+        animate={{
+          mount: { y: 0 },
+          unmount: { y: -50 },
+        }}
+      >
+        이미 가입된 그룹입니다.
+      </Alert>
       <div className='w-full'>
         <Typography variant='h4' className='font-normal'>
           <span className='font-bold'>[{groupName}]</span>에 가입해보세요.
@@ -48,8 +80,12 @@ const GroupJoinPage = () => {
           <Typography variant='h6'>{groupName}</Typography>
           <p className='text-xs min-w-[400px]'>{introduction}</p>
         </div>
-        {groupType === 'un_official_opened_group' && <UnOfficialOpenedGroup data={data} />}
-        {groupType === 'un_official_closed_group' && <UnOfficialClosedGroup data={data} />}
+        {groupType === 'un_official_opened_group' && (
+          <UnOfficialOpenedGroup data={data} onIsRegisteredAlertChange={handleIsRegisteredAlertOpen} />
+        )}
+        {groupType === 'un_official_closed_group' && (
+          <UnOfficialClosedGroup data={data} onIsRegisteredAlertChange={handleIsRegisteredAlertOpen} />
+        )}
         {groupType === 'official_group' && <OfficialGroup />}
       </div>
     </section>

--- a/src/pages/GroupJoinPage.tsx
+++ b/src/pages/GroupJoinPage.tsx
@@ -31,7 +31,7 @@ const GroupJoinPage = () => {
   useEffect(() => {
     const timer: NodeJS.Timeout = setTimeout(() => {
       setIsRegisteredAlertOpen(false);
-    }, 2000);
+    }, 3000);
 
     return () => clearTimeout(timer);
   }, [isRegisteredAlertOpen]);
@@ -43,19 +43,19 @@ const GroupJoinPage = () => {
   return (
     <section className='max-w-fit mx-auto'>
       <Alert
-        className='flex justify-between items-center py-3 font-semibold'
+        className='flex justify-between items-center py-3 font-semibold bg-gray-200 text-gray-600'
         open={isRegisteredAlertOpen}
         action={
           <Button
             variant='text'
-            className='p-1 text-white text-xs'
+            className='p-1 text-xs text-gray-600'
             onClick={() => navigate(`/${groupId}/${data.groupName}`)}
           >
             메인페이지로
           </Button>
         }
         animate={{
-          mount: { y: 0 },
+          mount: { y: -10 },
           unmount: { y: -50 },
         }}
       >

--- a/src/pages/GroupJoinPage.tsx
+++ b/src/pages/GroupJoinPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { Alert, Button, Typography } from '@material-tailwind/react';
@@ -8,13 +8,14 @@ import Logo from '@assets/images/logo/logo.svg';
 import OfficialGroup from '@components/JoinGroup/OfficialGroup';
 import UnOfficialOpenedGroup from '@components/JoinGroup/UnOfficialOpenedGroup';
 import UnOfficialClosedGroup from '@components/JoinGroup/UnOfficialClosedGroup';
+import useAlert from '@hooks/useAlert';
 
 const GroupJoinPage = () => {
   const navigate = useNavigate();
   const { groupId } = useParams();
   const numGroupId = Number(groupId);
   const [isImgError, setImageError] = useState<boolean>(false);
-  const [isRegisteredAlertOpen, setIsRegisteredAlertOpen] = useState<boolean>(false);
+  const { isOpen: isRegisteredAlertOpen, setIsOpen: setIsRegisteredAlertOpen } = useAlert();
   const { data, isLoading } = useQuery({
     queryKey: GROUP_KEYS.groupInfo({ groupId: numGroupId }),
     queryFn: () => getGroupInfoFn(numGroupId),
@@ -27,14 +28,6 @@ const GroupJoinPage = () => {
   const handleIsRegisteredAlertOpen = () => {
     setIsRegisteredAlertOpen((prev) => !prev);
   };
-
-  useEffect(() => {
-    const timer: NodeJS.Timeout = setTimeout(() => {
-      setIsRegisteredAlertOpen(false);
-    }, 3000);
-
-    return () => clearTimeout(timer);
-  }, [isRegisteredAlertOpen]);
 
   if (isLoading) {
     return <div>Loading...</div>;

--- a/src/pages/InviteProcessPage.tsx
+++ b/src/pages/InviteProcessPage.tsx
@@ -1,11 +1,16 @@
-import React from 'react';
-import { Spinner, Typography } from '@material-tailwind/react';
+import React, { Suspense } from 'react';
+import { useParams } from 'react-router-dom';
+import InviteFetcher from '@components/Invite/InviteFetcher';
+import { Spinner } from '@material-tailwind/react';
 
 const InviteProcessPage = () => {
+  const { inviteCode } = useParams() as { inviteCode: string };
+
   return (
-    <div className='absolute top-0 bottom-0 left-0 right-0 flex flex-col justify-center items-center gap-8 m-auto'>
-      <Typography variant='h5'>잠시만 기다려주세요.</Typography>
-      <Spinner className='h-12 w-12' />
+    <div className='absolute top-0 bottom-0 left-0 right-0 flex flex-col justify-center items-center gap-8'>
+      <Suspense fallback={<Spinner className='h-12 w-12' />}>
+        <InviteFetcher inviteCode={inviteCode} />
+      </Suspense>
     </div>
   );
 };

--- a/src/pages/InviteProcessPage.tsx
+++ b/src/pages/InviteProcessPage.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Spinner, Typography } from '@material-tailwind/react';
+
+const InviteProcessPage = () => {
+  return (
+    <div className='absolute top-0 bottom-0 left-0 right-0 flex flex-col justify-center items-center gap-8 m-auto'>
+      <Typography variant='h5'>잠시만 기다려주세요.</Typography>
+      <Spinner className='h-12 w-12' />
+    </div>
+  );
+};
+
+export default InviteProcessPage;

--- a/src/pages/InviteProcessPage.tsx
+++ b/src/pages/InviteProcessPage.tsx
@@ -1,16 +1,17 @@
-import React, { Suspense } from 'react';
+import React from 'react';
 import { useParams } from 'react-router-dom';
 import InviteFetcher from '@components/Invite/InviteFetcher';
-import { Spinner } from '@material-tailwind/react';
+import ErrorBoundary from '@components/Error/ErrorBoundary';
+import ErrorFallback from '@components/Error/ErrorFallback';
 
 const InviteProcessPage = () => {
   const { inviteCode } = useParams() as { inviteCode: string };
 
   return (
     <div className='absolute top-0 bottom-0 left-0 right-0 flex flex-col justify-center items-center gap-8'>
-      <Suspense fallback={<Spinner className='h-12 w-12' />}>
+      <ErrorBoundary fallback={ErrorFallback}>
         <InviteFetcher inviteCode={inviteCode} />
-      </Suspense>
+      </ErrorBoundary>
     </div>
   );
 };

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { RiKakaoTalkFill } from 'react-icons/ri';
 import { Button, Input } from '@material-tailwind/react';
 import { ReactComponent as TextLogo } from '@assets/images/logo/textLogo.svg';
@@ -28,10 +28,11 @@ const LoginPage = () => {
     formState: { errors, isValid },
   } = useForm<LoginInputs>({ mode: 'onChange' });
   const navigate = useNavigate();
+  const { state } = useLocation();
+  const setToken = useSetRecoilState(tokenState);
   const passwordFindModal = useModal();
 
   const { mutate: login, error } = useMutation({ mutationFn: loginFn });
-  const setToken = useSetRecoilState(tokenState);
 
   const handleLoginSubmit: SubmitHandler<FieldValues> = ({ email, password }) => {
     login(
@@ -39,6 +40,10 @@ const LoginPage = () => {
       {
         onSuccess: ({ grantType, accessToken }) => {
           setToken(`${grantType} ${accessToken}`);
+          if (state && state.path) {
+            navigate(state.path);
+            return;
+          }
           navigate('/');
         },
       },
@@ -48,7 +53,9 @@ const LoginPage = () => {
   return (
     <div className='flex min-h-full flex-col justify-center px-8'>
       <div className='mx-auto shadow space-y-4 w-full max-w-[450px] px-16 pt-9 pb-16'>
-        <TextLogo className='w-36 m-auto mb-8' data-testid='textLogo' />
+        <Link to='/'>
+          <TextLogo className='w-36 m-auto mb-8' data-testid='textLogo' />
+        </Link>
         <form className='space-y-12' onSubmit={handleSubmit(handleLoginSubmit)}>
           <div>
             <Input
@@ -82,7 +89,7 @@ const LoginPage = () => {
           </Button>
         </form>
         <div className='text-center text-xs'>
-          <Link to='/signUp' data-testid='signUpLink'>
+          <Link to='/signUp' data-testid='signUpLink' state={{ path: state?.path }}>
             회원가입
           </Link>
           {` | `}

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -12,7 +12,7 @@ import {
 } from '@constants/errorMsg';
 import { useMutation } from '@tanstack/react-query';
 import { signUpFn } from '@apis/authApi';
-import { useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 
 interface SignUpInputs {
   email: string;
@@ -29,6 +29,7 @@ const SignUpPage = () => {
     formState: { errors, isValid },
   } = useForm<SignUpInputs>({ mode: 'onChange' });
   const navigate = useNavigate();
+  const { state } = useLocation();
 
   const { mutate: signUp } = useMutation({ mutationFn: signUpFn });
 
@@ -37,7 +38,7 @@ const SignUpPage = () => {
       { email, password, name },
       {
         onSuccess: () => {
-          navigate('/login');
+          navigate('/login', { state: { path: state?.path } });
         },
       },
     );
@@ -46,7 +47,9 @@ const SignUpPage = () => {
   return (
     <div className='flex min-h-full flex-col justify-center px-8'>
       <div className='mx-auto space-y-4 w-full shadow max-w-[450px] px-16 pt-9 pb-16'>
-        <TextLogo className='w-36 m-auto mb-8' data-testid='textLogo' />
+        <Link to='/'>
+          <TextLogo className='w-36 m-auto mb-8' data-testid='textLogo' />
+        </Link>
         <form className='space-y-12' onSubmit={handleSubmit(handleSignUpSubmit)}>
           <div>
             <Input

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -23,3 +23,7 @@
   -ms-overflow-style: none; /* 인터넷 익스플로러 */
   scrollbar-width: none; /* 파이어폭스 */
 }
+
+iframe {
+  display: none;
+}

--- a/src/utils/Form/nickName.ts
+++ b/src/utils/Form/nickName.ts
@@ -36,5 +36,8 @@ export const nickNameRegister = {
     value: 8,
     message: GROUP_NICKNAME_ERROR_MSG,
   },
-  pattern: GROUP_NICKNAME_PATTERN,
+  pattern: {
+    value: GROUP_NICKNAME_PATTERN,
+    message: GROUP_NICKNAME_ERROR_MSG,
+  },
 };


### PR DESCRIPTION
## ⭐Key Changes

1. 헤더에서 그룹원 초대 버튼을 누르면 모달에 해당 그룹의 초대 링크가 생성됩니다.(현재는 주소가 localhost라 배포되면 코드 앞에 주소를 추가해야해서 이슈에 남겨놨습니다.)
2. 사용자가 링크를 타고 들어오면 상황에 맞게 리다이렉트 시킵니다.
    - 로그인 유저 -> 해당 그룹 가입페이지 (이미 그룹에 가입된 유저는 그룹 가입 시에 발생하는 에러로 처리)
    - 비로그인 유저 -> 로그인 페이지로 이동 (로그인 후 그룹 가입 페이지로 리다이렉트, 카카오 로그인은 기능 머지된 후에 처리하겠습니다.)

<br>

## 📌Issue

- close #165 

<br>

## 👪To Reviewers

헤더를 가지지 않는 레이아웃을 만들었고 로그인, 회원가입, 그룹가입 페이지를 이 레이아웃에 위치시켰습니다!


<br>

## 🐾Next Move

그룹가입 리다이렉트......
