### PR TITLE
그룹 가입 시 그룹 메인 페이지로 이동 안 되는 버그 픽스

### DIFF
--- a/src/hooks/useJoinMutation.ts
+++ b/src/hooks/useJoinMutation.ts
@@ -1,9 +1,11 @@
 import { AxiosError } from 'axios';
 import { useMutation } from '@tanstack/react-query';
+import { queryClient } from '@apis/queryClient';
 import { UseFormSetError } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import { joinGroupFn } from '@apis/groupApi';
 import { GROUP_EXIST_NICKNAME_ERROR_MSG } from '@constants/errorMsg';
+import { GROUP_KEYS, PAGE_KEYS } from '@constants/queryKeys';
 
 interface NickNameInput {
   nickName: string;
@@ -23,6 +25,12 @@ const useJoinMutation = ({ groupId, groupName, nickName, setError, onIsRegistere
   return useMutation({
     mutationFn: () => joinGroupFn({ groupId, nickName }),
     onSuccess: () => {
+      queryClient.invalidateQueries(PAGE_KEYS.byTitle({ groupId, title: groupName }), {
+        refetchType: 'all',
+      });
+      queryClient.invalidateQueries(GROUP_KEYS.members({ groupId }), {
+        refetchType: 'all',
+      });
       navigate(`/${groupId}/${groupName}`, { replace: true });
     },
     onError: (error) => {


### PR DESCRIPTION
## ⭐Key Changes
- 같은 쿼리 키로 인해 그룹 메인 페이지의 쿼리가 업데이트 되지 않는 상황이어서 그룹 가입 전과 같은 캐싱된 에러로 인해 다시 그룹 가입페이지로 리다이렉트 되는 문제가 있었습니다.
- 먼저 `invalidateQueries`를 사용해 캐싱된 데이터를 무효화 해주었고
- 이 과정에서 `refetchType: 'all'` 로 지정해서 `inactive` 상태인 쿼리도 `invalidate` 되도록 처리하였습니다.

## 📌Issue

- Close #184 
