### PR TITLE
댓글 엔터 글자 입력 제한 및 trim 처리

### DIFF
--- a/src/components/Page/Post/CommentList.tsx
+++ b/src/components/Page/Post/CommentList.tsx
@@ -44,12 +44,12 @@ const CommentList = ({ groupId, postId, commentRef, isOpen, onCommentClose }: Co
   });
 
   const handleCreateComment = () => {
-    if (!text) return;
-    createComment({ groupId, postId, content: text });
+    if (!text.trim()) return;
+    createComment({ groupId, postId, content: text.trim() });
   };
 
   const handleCreateCommentOnEnter = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (!text) return;
+    if (!text.trim()) return;
     if (e.key === 'Enter' && !e.shiftKey && e.nativeEvent.isComposing === false) {
       e.preventDefault();
       handleCreateComment();
@@ -57,6 +57,8 @@ const CommentList = ({ groupId, postId, commentRef, isOpen, onCommentClose }: Co
   };
 
   const handleChangeText = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    if (e.target.value === '\n') return;
+
     setText(e.target.value);
     // Textarea 높이 자동 조절
     e.target.style.height = 'auto';
@@ -96,7 +98,7 @@ const CommentList = ({ groupId, postId, commentRef, isOpen, onCommentClose }: Co
         />
         <button
           type='submit'
-          disabled={!text}
+          disabled={!text.trim()}
           className={`absolute right-5 bottom-5 p-[6px] rounded-full ${text ? 'hover:bg-gray-200' : ''}`}
           onClick={handleCreateComment}
         >


### PR DESCRIPTION
## ⭐Key Changes

- 엔터 클릭 시 개행 문자가 입력되고 댓글이 바로 생성되는 문제가 있어서,
onChange 시에 개행의 경우 입력이 안 되도록 처리하였고,
slack 참고하여 trim 처리도 같이 해주었습니다.
